### PR TITLE
feat(kernel): Add @wordpress/data store integration (A3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,45 @@ _No unreleased changes yet._
 
 ---
 
+## [0.1.1] - 2025-10-01
+
+### Added - Sprint 1 A3: @wordpress/data Store Integration
+
+#### Store Factory
+
+- **createStore factory** - Generates typed @wordpress/data stores from ResourceObject definitions (closes #3)
+- **Automatic store registration** - Lazy-loaded stores auto-register with window.wp.data on first access
+- **TypeScript store types** - Full type definitions for ResourceState, ResourceActions, ResourceSelectors, ResourceResolvers, ResourceStoreConfig, ResourceStore
+- **Normalized state management** - Items stored by ID with separate lists and metadata tracking
+- **Redux-compatible reducer** - Handles RECEIVE_ITEM, RECEIVE_ITEMS, RECEIVE_ERROR, INVALIDATE, INVALIDATE_ALL actions
+- **Declarative data fetching** - Resolvers automatically fetch data when selectors are used (WordPress data layer pattern)
+- **Resolution tracking** - Built-in isResolving, hasStartedResolution, hasFinishedResolution selectors
+- **Error handling** - Stores errors by cache key with getError selector
+- **Custom configuration** - Support for custom getId and getQueryKey functions, plus initial state
+
+#### Resource Integration
+
+- **Lazy store property** - Added `store` getter to ResourceObject for on-demand store creation
+- **Zero configuration** - Stores automatically use resource name, routes, and cache keys
+- **Seamless WordPress integration** - Works with @wordpress/data select/dispatch/useSelect APIs
+
+#### Documentation
+
+- **Comprehensive store guide** - Added complete @wordpress/data integration section to docs/guide/resources.md
+- **Selector examples** - Documented all selectors (getItem, getItems, getList, getError, resolution helpers)
+- **Resolver patterns** - Explained automatic data fetching and error handling
+- **Best practices** - Four key patterns for using stores effectively
+
+#### Testing
+
+- **36 new test cases** - Comprehensive coverage for createStore factory
+- **Store module coverage** - 93.82% coverage for store creation, reducer, actions, selectors, resolvers
+- **defineResource tests** - Added 6 tests for lazy store initialization (window.wp.data registration)
+- **Overall coverage** - Improved from 91.6% to 94.8%
+- **defineResource coverage** - Improved from 80% to 92.53%
+
+---
+
 ## [0.1.0] - 2025-10-01
 
 ### Sprint 0 Complete! 🎉 (100%, 18/18 Tasks)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-kernel",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"private": true,
 	"type": "module",
 	"description": "A Rails-like, opinionated framework for building modern WordPress products",

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@geekist/wp-kernel",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Rails-like framework for building modern WordPress products",
 	"license": "EUPL-1.2",
 	"type": "module",

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -26,6 +26,7 @@ export type {
  * Resource system (Sprint 1)
  */
 export { defineResource, interpolatePath, extractPathParams } from './resource';
+export { createStore } from './resource/store/createStore';
 export type {
 	HttpMethod,
 	ResourceRoute,
@@ -38,6 +39,14 @@ export type {
 	ResourceObject,
 	PathParams,
 } from './resource';
+export type {
+	ResourceState,
+	ResourceActions,
+	ResourceSelectors,
+	ResourceResolvers,
+	ResourceStoreConfig,
+	ResourceStore,
+} from './resource/store/types';
 
 /**
  * Module placeholders - implementations coming in future sprints

--- a/packages/kernel/src/resource/store/__tests__/createStore.test.ts
+++ b/packages/kernel/src/resource/store/__tests__/createStore.test.ts
@@ -263,7 +263,10 @@ describe('createStore', () => {
 		});
 
 		it('should handle invalid action objects gracefully', () => {
-			const invalidAction = 'not an object' as any;
+			// Intentionally pass invalid type to test error handling
+			const invalidAction = 'not an object' as unknown as {
+				type: string;
+			};
 
 			const state = store.reducer(undefined, invalidAction);
 

--- a/packages/kernel/src/resource/store/__tests__/createStore.test.ts
+++ b/packages/kernel/src/resource/store/__tests__/createStore.test.ts
@@ -1,0 +1,688 @@
+/**
+ * Unit tests for createStore factory
+ *
+ * Tests the @wordpress/data store integration
+ */
+
+import { createStore } from '../createStore';
+import type { ResourceObject, ListResponse } from '../../types';
+import { KernelError } from '../../../errors';
+
+// Mock resource for testing
+interface MockThing {
+	id: number;
+	title: string;
+	status: string;
+}
+
+interface MockThingQuery {
+	q?: string;
+	status?: string;
+}
+
+describe('createStore', () => {
+	let mockResource: ResourceObject<MockThing, MockThingQuery>;
+	let mockListResponse: ListResponse<MockThing>;
+
+	beforeEach(() => {
+		mockListResponse = {
+			items: [
+				{ id: 1, title: 'Thing One', status: 'active' },
+				{ id: 2, title: 'Thing Two', status: 'inactive' },
+			],
+			total: 2,
+			hasMore: false,
+		};
+
+		mockResource = {
+			name: 'thing',
+			storeKey: 'gk/thing',
+			cacheKeys: {
+				list: (query) => ['thing', 'list', JSON.stringify(query || {})],
+				get: (id) => ['thing', 'get', id],
+				create: (data) => [
+					'thing',
+					'create',
+					JSON.stringify(data || {}),
+				],
+				update: (id) => ['thing', 'update', id],
+				remove: (id) => ['thing', 'remove', id],
+			},
+			routes: {
+				list: { path: '/gk/v1/things', method: 'GET' },
+				get: { path: '/gk/v1/things/:id', method: 'GET' },
+			},
+			list: jest.fn().mockResolvedValue(mockListResponse),
+			get: jest.fn().mockResolvedValue({
+				id: 1,
+				title: 'Thing One',
+				status: 'active',
+			}),
+			store: {},
+		};
+	});
+
+	describe('store creation', () => {
+		it('should create a store descriptor with correct structure', () => {
+			const store = createStore({
+				resource: mockResource,
+			});
+
+			expect(store).toHaveProperty('storeKey', 'gk/thing');
+			expect(store).toHaveProperty('reducer');
+			expect(store).toHaveProperty('actions');
+			expect(store).toHaveProperty('selectors');
+			expect(store).toHaveProperty('resolvers');
+			expect(store).toHaveProperty('initialState');
+		});
+
+		it('should use custom getId function when provided', () => {
+			const customGetId = (item: MockThing) => `custom-${item.id}`;
+			const store = createStore({
+				resource: mockResource,
+				getId: customGetId,
+			});
+
+			expect(store).toBeDefined();
+			// getId is used internally in reducer, test via action
+		});
+
+		it('should use custom getQueryKey function when provided', () => {
+			const customGetQueryKey = (query?: MockThingQuery) =>
+				`custom-${JSON.stringify(query)}`;
+			const store = createStore({
+				resource: mockResource,
+				getQueryKey: customGetQueryKey,
+			});
+
+			expect(store).toBeDefined();
+		});
+
+		it('should merge custom initial state', () => {
+			const customInitialState = {
+				items: { 99: { id: 99, title: 'Preset', status: 'active' } },
+			};
+			const store = createStore({
+				resource: mockResource,
+				initialState: customInitialState,
+			});
+
+			// Create initial state and check
+			const state = store.reducer(undefined, { type: '@@INIT' });
+			expect(state.items).toHaveProperty('99');
+			expect(state.items[99]).toEqual({
+				id: 99,
+				title: 'Preset',
+				status: 'active',
+			});
+		});
+	});
+
+	describe('reducer', () => {
+		let store: ReturnType<typeof createStore<MockThing, MockThingQuery>>;
+
+		beforeEach(() => {
+			store = createStore({
+				resource: mockResource,
+			});
+		});
+
+		it('should initialize with empty state', () => {
+			const state = store.reducer(undefined, { type: '@@INIT' });
+
+			expect(state).toEqual({
+				items: {},
+				lists: {},
+				listMeta: {},
+				errors: {},
+			});
+		});
+
+		it('should handle RECEIVE_ITEM action', () => {
+			const item: MockThing = {
+				id: 1,
+				title: 'Thing One',
+				status: 'active',
+			};
+			const action = {
+				type: 'RECEIVE_ITEM',
+				item,
+			};
+
+			const state = store.reducer(undefined, action);
+
+			expect(state.items[1]).toEqual(item);
+		});
+
+		it('should handle RECEIVE_ITEMS action', () => {
+			const items: MockThing[] = [
+				{ id: 1, title: 'Thing One', status: 'active' },
+				{ id: 2, title: 'Thing Two', status: 'inactive' },
+			];
+			const queryKey = '{"q":"search"}';
+			const meta = { total: 2, hasMore: false };
+			const action = {
+				type: 'RECEIVE_ITEMS',
+				items,
+				queryKey,
+				meta,
+			};
+
+			const state = store.reducer(undefined, action);
+
+			expect(state.items[1]).toEqual(items[0]);
+			expect(state.items[2]).toEqual(items[1]);
+			expect(state.lists[queryKey]).toEqual([1, 2]);
+			expect(state.listMeta[queryKey]).toEqual(meta);
+		});
+
+		it('should handle RECEIVE_ERROR action', () => {
+			const cacheKey = 'thing:get:1';
+			const error = 'Not found';
+			const action = {
+				type: 'RECEIVE_ERROR',
+				cacheKey,
+				error,
+			};
+
+			const state = store.reducer(undefined, action);
+
+			expect(state.errors[cacheKey]).toBe(error);
+		});
+
+		it('should handle INVALIDATE action', () => {
+			// Setup state with data
+			const setupAction1 = {
+				type: 'RECEIVE_ITEMS',
+				items: [{ id: 1, title: 'Thing One', status: 'active' }],
+				queryKey: 'query1',
+				meta: {},
+			};
+			const setupAction2 = {
+				type: 'RECEIVE_ITEMS',
+				items: [{ id: 2, title: 'Thing Two', status: 'inactive' }],
+				queryKey: 'query2',
+				meta: {},
+			};
+			let state = store.reducer(undefined, setupAction1);
+			state = store.reducer(state, setupAction2);
+
+			// Invalidate one query
+			const invalidateAction = {
+				type: 'INVALIDATE',
+				cacheKeys: ['query1'],
+			};
+			state = store.reducer(state, invalidateAction);
+
+			expect(state.lists).not.toHaveProperty('query1');
+			expect(state.lists).toHaveProperty('query2');
+		});
+
+		it('should handle INVALIDATE_ALL action', () => {
+			// Setup state with data
+			const setupAction = {
+				type: 'RECEIVE_ITEMS',
+				items: [
+					{ id: 1, title: 'Thing One', status: 'active' },
+					{ id: 2, title: 'Thing Two', status: 'inactive' },
+				],
+				queryKey: 'query1',
+				meta: {},
+			};
+			let state = store.reducer(undefined, setupAction);
+
+			// Invalidate all
+			const invalidateAllAction = {
+				type: 'INVALIDATE_ALL',
+			};
+			state = store.reducer(state, invalidateAllAction);
+
+			expect(state).toEqual({
+				items: {},
+				lists: {},
+				listMeta: {},
+				errors: {},
+			});
+		});
+
+		it('should handle unknown action types gracefully', () => {
+			const unknownAction = {
+				type: 'UNKNOWN_ACTION',
+				payload: 'test',
+			};
+
+			const state = store.reducer(undefined, unknownAction);
+
+			// Should return initial state unchanged
+			expect(state).toEqual({
+				items: {},
+				lists: {},
+				listMeta: {},
+				errors: {},
+			});
+		});
+
+		it('should handle invalid action objects gracefully', () => {
+			const invalidAction = 'not an object' as any;
+
+			const state = store.reducer(undefined, invalidAction);
+
+			// Should return initial state
+			expect(state).toEqual({
+				items: {},
+				lists: {},
+				listMeta: {},
+				errors: {},
+			});
+		});
+	});
+
+	describe('actions', () => {
+		let store: ReturnType<typeof createStore<MockThing, MockThingQuery>>;
+
+		beforeEach(() => {
+			store = createStore({
+				resource: mockResource,
+			});
+		});
+
+		it('should create receiveItem action', () => {
+			const item: MockThing = {
+				id: 1,
+				title: 'Thing One',
+				status: 'active',
+			};
+			const action = store.actions.receiveItem(item);
+
+			expect(action).toEqual({
+				type: 'RECEIVE_ITEM',
+				item,
+			});
+		});
+
+		it('should create receiveItems action', () => {
+			const items: MockThing[] = [
+				{ id: 1, title: 'Thing One', status: 'active' },
+			];
+			const queryKey = 'query1';
+			const meta = { total: 1, hasMore: false };
+
+			const action = store.actions.receiveItems(queryKey, items, meta);
+
+			expect(action).toEqual({
+				type: 'RECEIVE_ITEMS',
+				queryKey,
+				items,
+				meta,
+			});
+		});
+
+		it('should create receiveError action', () => {
+			const cacheKey = 'thing:get:1';
+			const error = 'Not found';
+
+			const action = store.actions.receiveError(cacheKey, error);
+
+			expect(action).toEqual({
+				type: 'RECEIVE_ERROR',
+				cacheKey,
+				error,
+			});
+		});
+
+		it('should create invalidate action', () => {
+			const cacheKeys = ['query1', 'query2'];
+
+			const action = store.actions.invalidate(cacheKeys);
+
+			expect(action).toEqual({
+				type: 'INVALIDATE',
+				cacheKeys,
+			});
+		});
+
+		it('should create invalidateAll action', () => {
+			const action = store.actions.invalidateAll();
+
+			expect(action).toEqual({
+				type: 'INVALIDATE_ALL',
+			});
+		});
+	});
+
+	describe('selectors', () => {
+		let store: ReturnType<typeof createStore<MockThing, MockThingQuery>>;
+		let stateWithData: ReturnType<typeof store.reducer>;
+
+		beforeEach(() => {
+			store = createStore({
+				resource: mockResource,
+			});
+
+			// Setup state with test data
+			stateWithData = store.reducer(
+				undefined,
+				store.actions.receiveItems(
+					'query1',
+					[
+						{ id: 1, title: 'Thing One', status: 'active' },
+						{ id: 2, title: 'Thing Two', status: 'inactive' },
+					],
+					{ total: 2, hasMore: false }
+				)
+			);
+		});
+
+		it('should select item by ID', () => {
+			const item = store.selectors.getItem(stateWithData, 1);
+
+			expect(item).toEqual({
+				id: 1,
+				title: 'Thing One',
+				status: 'active',
+			});
+		});
+
+		it('should return undefined for non-existent item', () => {
+			const item = store.selectors.getItem(stateWithData, 999);
+
+			expect(item).toBeUndefined();
+		});
+
+		it('should select all items from a query', () => {
+			// The data was stored with queryKey 'query1', need to use getItems with undefined query
+			// getItems() with no query will use getQueryKey(undefined) which won't match 'query1'
+			// Let's use a proper query setup
+			const query = {};
+			const queryKey = JSON.stringify(query);
+			const stateWithQuery = store.reducer(
+				undefined,
+				store.actions.receiveItems(
+					queryKey,
+					[
+						{ id: 1, title: 'Thing One', status: 'active' },
+						{ id: 2, title: 'Thing Two', status: 'inactive' },
+					],
+					{ total: 2, hasMore: false }
+				)
+			);
+
+			const items = store.selectors.getItems(stateWithQuery, query);
+
+			expect(items).toHaveLength(2);
+			expect(items[0]).toEqual({
+				id: 1,
+				title: 'Thing One',
+				status: 'active',
+			});
+			expect(items[1]).toEqual({
+				id: 2,
+				title: 'Thing Two',
+				status: 'inactive',
+			});
+		});
+
+		it('should select list by query key', () => {
+			// The data was stored with queryKey 'query1', so we need to query with that same key
+			// Since getList uses getQueryKey internally, we need to understand what query produces 'query1'
+			// For this test, let's re-setup with a proper query
+			const query = { q: 'search' };
+			const queryKey = JSON.stringify(query);
+			const stateWithQuery = store.reducer(
+				undefined,
+				store.actions.receiveItems(
+					queryKey,
+					[
+						{ id: 1, title: 'Thing One', status: 'active' },
+						{ id: 2, title: 'Thing Two', status: 'inactive' },
+					],
+					{ total: 2, hasMore: false }
+				)
+			);
+
+			const result = store.selectors.getList(stateWithQuery, query);
+
+			expect(result.items).toEqual([
+				{ id: 1, title: 'Thing One', status: 'active' },
+				{ id: 2, title: 'Thing Two', status: 'inactive' },
+			]);
+			expect(result.total).toBe(2);
+			expect(result.hasMore).toBe(false);
+		});
+
+		it('should return empty list for non-existent query', () => {
+			const result = store.selectors.getList(stateWithData, {
+				q: 'nonexistent',
+			});
+
+			expect(result.items).toEqual([]);
+			expect(result.total).toBeUndefined();
+		});
+
+		it('should select error by cache key', () => {
+			const stateWithError = store.reducer(
+				undefined,
+				store.actions.receiveError('thing:get:1', 'Not found')
+			);
+
+			const error = store.selectors.getError(
+				stateWithError,
+				'thing:get:1'
+			);
+
+			expect(error).toBe('Not found');
+		});
+
+		it('should return undefined for non-existent error', () => {
+			const error = store.selectors.getError(
+				stateWithData,
+				'thing:get:999'
+			);
+
+			expect(error).toBeUndefined();
+		});
+	});
+
+	describe('resolvers', () => {
+		let store: ReturnType<typeof createStore<MockThing, MockThingQuery>>;
+
+		beforeEach(() => {
+			store = createStore({
+				resource: mockResource,
+			});
+		});
+
+		describe('getItem', () => {
+			it('should fetch item and return receiveItem action', async () => {
+				const item = { id: 1, title: 'Thing One', status: 'active' };
+				(mockResource.get as jest.Mock).mockResolvedValue(item);
+
+				const action = await store.resolvers.getItem(1);
+
+				expect(mockResource.get).toHaveBeenCalledWith(1);
+				expect(action).toEqual({
+					type: 'RECEIVE_ITEM',
+					item,
+				});
+			});
+
+			it('should return receiveError action on fetch failure', async () => {
+				const error = new Error('Network error');
+				(mockResource.get as jest.Mock).mockRejectedValue(error);
+
+				const action = await store.resolvers.getItem(1);
+
+				expect(action).toEqual({
+					type: 'RECEIVE_ERROR',
+					cacheKey: 'thing:get:1',
+					error: 'Network error',
+				});
+			});
+
+			it('should throw NotImplementedError when get method not defined', async () => {
+				const resourceWithoutGet = {
+					...mockResource,
+					get: undefined,
+				};
+
+				const storeWithoutGet = createStore({
+					resource: resourceWithoutGet,
+				});
+
+				await expect(
+					storeWithoutGet.resolvers.getItem(1)
+				).rejects.toThrow(KernelError);
+				await expect(
+					storeWithoutGet.resolvers.getItem(1)
+				).rejects.toThrow(/does not have a "get" method/);
+			});
+		});
+
+		describe('getItems', () => {
+			it('should fetch items and return receiveItems action', async () => {
+				const query = { q: 'search' };
+				(mockResource.list as jest.Mock).mockResolvedValue(
+					mockListResponse
+				);
+
+				const action = await store.resolvers.getItems(query);
+
+				expect(mockResource.list).toHaveBeenCalledWith(query);
+				expect(action).toEqual({
+					type: 'RECEIVE_ITEMS',
+					queryKey: JSON.stringify(query),
+					items: mockListResponse.items,
+					meta: {
+						total: mockListResponse.total,
+						hasMore: mockListResponse.hasMore,
+						nextCursor: mockListResponse.nextCursor,
+					},
+				});
+			});
+
+			it('should handle query without parameters', async () => {
+				(mockResource.list as jest.Mock).mockResolvedValue(
+					mockListResponse
+				);
+
+				const action = await store.resolvers.getItems();
+
+				expect(mockResource.list).toHaveBeenCalledWith(undefined);
+				expect(action).toHaveProperty('type', 'RECEIVE_ITEMS');
+				expect(action).toHaveProperty('queryKey');
+			});
+
+			it('should return receiveError action on fetch failure', async () => {
+				const error = new Error('Network error');
+				(mockResource.list as jest.Mock).mockRejectedValue(error);
+
+				const action = await store.resolvers.getItems();
+
+				expect(action).toEqual({
+					type: 'RECEIVE_ERROR',
+					cacheKey: 'thing:list:{}',
+					error: 'Network error',
+				});
+			});
+
+			it('should throw NotImplementedError when list method not defined', async () => {
+				const resourceWithoutList = {
+					...mockResource,
+					list: undefined,
+				};
+
+				const storeWithoutList = createStore({
+					resource: resourceWithoutList,
+				});
+
+				await expect(
+					storeWithoutList.resolvers.getItems()
+				).rejects.toThrow(KernelError);
+				await expect(
+					storeWithoutList.resolvers.getItems()
+				).rejects.toThrow(/does not have a "list" method/);
+			});
+		});
+
+		describe('getList', () => {
+			it('should delegate to getItems resolver', async () => {
+				const query = { status: 'active' };
+				(mockResource.list as jest.Mock).mockResolvedValue(
+					mockListResponse
+				);
+
+				const action = await store.resolvers.getList(query);
+
+				expect(mockResource.list).toHaveBeenCalledWith(query);
+				expect(action).toEqual({
+					type: 'RECEIVE_ITEMS',
+					queryKey: JSON.stringify(query),
+					items: mockListResponse.items,
+					meta: {
+						total: mockListResponse.total,
+						hasMore: mockListResponse.hasMore,
+						nextCursor: mockListResponse.nextCursor,
+					},
+				});
+			});
+		});
+	});
+
+	describe('cache key generation', () => {
+		it('should use default getId with id property', () => {
+			const store = createStore({
+				resource: mockResource,
+			});
+
+			const item = { id: 123, title: 'Test', status: 'active' };
+			const state = store.reducer(
+				undefined,
+				store.actions.receiveItem(item)
+			);
+
+			expect(state.items[123]).toEqual(item);
+		});
+
+		it('should use default getQueryKey with JSON.stringify', () => {
+			const store = createStore({
+				resource: mockResource,
+			});
+
+			const query = { q: 'search', status: 'active' };
+			const expectedKey = JSON.stringify(query);
+			const action = store.actions.receiveItems(expectedKey, [], {});
+
+			expect(action).toHaveProperty('queryKey', expectedKey);
+		});
+
+		it('should use custom getId function', () => {
+			const customGetId = (item: MockThing) => `thing-${item.id}`;
+			const store = createStore({
+				resource: mockResource,
+				getId: customGetId,
+			});
+
+			const item = { id: 123, title: 'Test', status: 'active' };
+			const state = store.reducer(
+				undefined,
+				store.actions.receiveItem(item)
+			);
+
+			expect(state.items['thing-123']).toEqual(item);
+		});
+
+		it('should use custom getQueryKey function', () => {
+			const customGetQueryKey = (query?: MockThingQuery) =>
+				`custom-${query?.q || 'all'}`;
+			const store = createStore({
+				resource: mockResource,
+				getQueryKey: customGetQueryKey,
+			});
+
+			const expectedKey = 'custom-search';
+			const action = store.actions.receiveItems(expectedKey, [], {});
+
+			expect(action).toHaveProperty('queryKey', expectedKey);
+		});
+	});
+});

--- a/packages/kernel/src/resource/store/createStore.ts
+++ b/packages/kernel/src/resource/store/createStore.ts
@@ -1,0 +1,367 @@
+/**
+ * @file Store Factory
+ * Creates @wordpress/data stores from resource definitions.
+ *
+ * This factory function handles all the boilerplate of creating a Redux-like store
+ * that's compatible with WordPress's data layer.
+ */
+
+import type {
+	ResourceState,
+	ResourceActions,
+	ResourceSelectors,
+	ResourceResolvers,
+	ResourceStore,
+	ResourceStoreConfig,
+} from './types';
+import type { ListResponse } from '../types';
+import { KernelError } from '../../errors';
+
+/**
+ * Action types for the resource store.
+ */
+const ACTION_TYPES = {
+	RECEIVE_ITEM: 'RECEIVE_ITEM',
+	RECEIVE_ITEMS: 'RECEIVE_ITEMS',
+	RECEIVE_ERROR: 'RECEIVE_ERROR',
+	INVALIDATE: 'INVALIDATE',
+	INVALIDATE_ALL: 'INVALIDATE_ALL',
+} as const;
+
+/**
+ * Default function to extract ID from an item.
+ * Assumes the item has an `id` property.
+ * @param item
+ */
+function defaultGetId<T>(item: T): string | number {
+	return (item as { id: string | number }).id;
+}
+
+/**
+ * Default function to generate query key from query params.
+ * @param query
+ */
+function defaultGetQueryKey<TQuery>(query?: TQuery): string {
+	return JSON.stringify(query || {});
+}
+
+/**
+ * Creates a resource store with selectors, actions, and resolvers.
+ *
+ * @template T - The resource entity type
+ * @template TQuery - The query parameter type for list operations
+ * @param    config - Store configuration
+ * @return Complete store descriptor
+ *
+ * @example
+ * ```typescript
+ * import { createStore } from '@geekist/wp-kernel/resource';
+ * import { thing } from './resources/thing';
+ *
+ * const thingStore = createStore({
+ *   resource: thing,
+ *   getId: (item) => item.id,
+ * });
+ * ```
+ */
+export function createStore<T, TQuery = unknown>(
+	config: ResourceStoreConfig<T, TQuery>
+): ResourceStore<T, TQuery> {
+	const {
+		resource,
+		initialState: customInitialState = {},
+		getId = defaultGetId,
+		getQueryKey = defaultGetQueryKey,
+	} = config;
+
+	const storeKey = resource.storeKey;
+
+	// Initial state
+	const initialState: ResourceState<T> = {
+		items: {},
+		lists: {},
+		listMeta: {},
+		errors: {},
+		...customInitialState,
+	};
+
+	// Reducer
+	function reducer(
+		state: ResourceState<T> = initialState,
+		action: unknown
+	): ResourceState<T> {
+		// Type guard for action objects
+		if (
+			typeof action !== 'object' ||
+			action === null ||
+			!('type' in action)
+		) {
+			return state;
+		}
+
+		const typedAction = action as {
+			type: string;
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			[key: string]: any;
+		};
+
+		switch (typedAction.type) {
+			case ACTION_TYPES.RECEIVE_ITEM: {
+				const item = typedAction.item as T;
+				const id = getId(item);
+				return {
+					...state,
+					items: {
+						...state.items,
+						[id]: item,
+					},
+				};
+			}
+
+			case ACTION_TYPES.RECEIVE_ITEMS: {
+				const items = typedAction.items as T[];
+				const queryKey = typedAction.queryKey as string;
+				const meta =
+					typedAction.meta as ResourceState<T>['listMeta'][string];
+
+				const newItems = { ...state.items };
+				const ids: (string | number)[] = [];
+
+				items.forEach((item) => {
+					const id = getId(item);
+					newItems[id] = item;
+					ids.push(id);
+				});
+
+				return {
+					...state,
+					items: newItems,
+					lists: {
+						...state.lists,
+						[queryKey]: ids,
+					},
+					listMeta: {
+						...state.listMeta,
+						[queryKey]: meta || {},
+					},
+				};
+			}
+
+			case ACTION_TYPES.RECEIVE_ERROR: {
+				const cacheKey = typedAction.cacheKey as string;
+				const error = typedAction.error as string;
+
+				return {
+					...state,
+					errors: {
+						...state.errors,
+						[cacheKey]: error,
+					},
+				};
+			}
+
+			case ACTION_TYPES.INVALIDATE: {
+				const cacheKeys = typedAction.cacheKeys as string[];
+				const newLists = { ...state.lists };
+				const newListMeta = { ...state.listMeta };
+				const newErrors = { ...state.errors };
+
+				cacheKeys.forEach((key) => {
+					delete newLists[key];
+					delete newListMeta[key];
+					delete newErrors[key];
+				});
+
+				return {
+					...state,
+					lists: newLists,
+					listMeta: newListMeta,
+					errors: newErrors,
+				};
+			}
+
+			case ACTION_TYPES.INVALIDATE_ALL: {
+				return {
+					items: {},
+					lists: {},
+					listMeta: {},
+					errors: {},
+				};
+			}
+
+			default:
+				return state;
+		}
+	}
+
+	// Actions
+	const actions: ResourceActions<T> = {
+		receiveItem(item: T) {
+			return {
+				type: ACTION_TYPES.RECEIVE_ITEM,
+				item,
+			};
+		},
+
+		receiveItems(queryKey: string, items: T[], meta) {
+			return {
+				type: ACTION_TYPES.RECEIVE_ITEMS,
+				queryKey,
+				items,
+				meta,
+			};
+		},
+
+		receiveError(cacheKey: string, error: string) {
+			return {
+				type: ACTION_TYPES.RECEIVE_ERROR,
+				cacheKey,
+				error,
+			};
+		},
+
+		invalidate(cacheKeys: string[]) {
+			return {
+				type: ACTION_TYPES.INVALIDATE,
+				cacheKeys,
+			};
+		},
+
+		invalidateAll() {
+			return {
+				type: ACTION_TYPES.INVALIDATE_ALL,
+			};
+		},
+	};
+
+	// Selectors
+	const selectors: ResourceSelectors<T, TQuery> = {
+		getItem(state: ResourceState<T>, id: string | number): T | undefined {
+			return state.items[id];
+		},
+
+		getItems(state: ResourceState<T>, query?: TQuery): T[] {
+			const queryKey = getQueryKey(query);
+			const ids = state.lists[queryKey] || [];
+			return ids.map((id) => state.items[id]).filter(Boolean) as T[];
+		},
+
+		getList(state: ResourceState<T>, query?: TQuery): ListResponse<T> {
+			const queryKey = getQueryKey(query);
+			const items = selectors.getItems(state, query);
+			const meta = state.listMeta[queryKey] || {};
+
+			return {
+				items,
+				total: meta.total,
+				hasMore: meta.hasMore,
+				nextCursor: meta.nextCursor,
+			};
+		},
+
+		// Note: These are provided by @wordpress/data's resolution system
+		// We include them here for type completeness
+		isResolving(
+			_state: ResourceState<T>,
+			_selectorName: string,
+			_args?: unknown[]
+		): boolean {
+			// This will be overridden by @wordpress/data
+			return false;
+		},
+
+		hasStartedResolution(
+			_state: ResourceState<T>,
+			_selectorName: string,
+			_args?: unknown[]
+		): boolean {
+			// This will be overridden by @wordpress/data
+			return false;
+		},
+
+		hasFinishedResolution(
+			_state: ResourceState<T>,
+			_selectorName: string,
+			_args?: unknown[]
+		): boolean {
+			// This will be overridden by @wordpress/data
+			return false;
+		},
+
+		getError(
+			state: ResourceState<T>,
+			cacheKey: string
+		): string | undefined {
+			return state.errors[cacheKey];
+		},
+	};
+
+	// Resolvers
+	const resolvers: ResourceResolvers<T, TQuery> = {
+		async getItem(id: string | number): Promise<void> {
+			// Check if client method exists
+			if (!resource.get) {
+				throw new KernelError('NotImplementedError', {
+					message:
+						`Resource "${resource.name}" does not have a "get" method. ` +
+						'Define a "get" route in your resource configuration.',
+				});
+			}
+
+			try {
+				const item = await resource.get(id);
+				return actions.receiveItem(item);
+			} catch (error) {
+				const cacheKey =
+					resource.cacheKeys.get?.(id).join(':') ||
+					`${resource.name}:get:${id}`;
+				const errorMessage =
+					error instanceof Error ? error.message : 'Unknown error';
+				return actions.receiveError(cacheKey, errorMessage);
+			}
+		},
+
+		async getItems(query?: TQuery): Promise<void> {
+			// Check if client method exists
+			if (!resource.list) {
+				throw new KernelError('NotImplementedError', {
+					message:
+						`Resource "${resource.name}" does not have a "list" method. ` +
+						'Define a "list" route in your resource configuration.',
+				});
+			}
+
+			const queryKey = getQueryKey(query);
+
+			try {
+				const response = await resource.list(query);
+				return actions.receiveItems(queryKey, response.items, {
+					total: response.total,
+					hasMore: response.hasMore,
+					nextCursor: response.nextCursor,
+				});
+			} catch (error) {
+				const cacheKey =
+					resource.cacheKeys.list?.(query).join(':') ||
+					`${resource.name}:list:${queryKey}`;
+				const errorMessage =
+					error instanceof Error ? error.message : 'Unknown error';
+				return actions.receiveError(cacheKey, errorMessage);
+			}
+		},
+
+		// getList uses the same resolver as getItems
+		async getList(query?: TQuery): Promise<void> {
+			return resolvers.getItems(query);
+		},
+	};
+
+	return {
+		storeKey,
+		selectors,
+		actions,
+		resolvers,
+		reducer,
+		initialState,
+	};
+}

--- a/packages/kernel/src/resource/store/index.ts
+++ b/packages/kernel/src/resource/store/index.ts
@@ -1,0 +1,15 @@
+/**
+ * WordPress data store integration
+ *
+ * Creates typed stores from resource definitions
+ */
+
+export { createStore } from './createStore';
+export type {
+	ResourceState,
+	ResourceActions,
+	ResourceSelectors,
+	ResourceResolvers,
+	ResourceStoreConfig,
+	ResourceStore,
+} from './types';

--- a/packages/kernel/src/resource/store/types.ts
+++ b/packages/kernel/src/resource/store/types.ts
@@ -1,0 +1,291 @@
+/**
+ * Types for @wordpress/data store integration.
+ *
+ * @module resource/store/types
+ */
+
+import type { ResourceObject, ListResponse } from '../types';
+
+/**
+ * State shape for a resource store.
+ *
+ * @template T - The resource entity type
+ */
+export interface ResourceState<T> {
+	/**
+	 * Map of items by ID.
+	 */
+	items: Record<string | number, T>;
+
+	/**
+	 * List queries and their results.
+	 * Key is stringified query params, value is array of IDs.
+	 */
+	lists: Record<string, (string | number)[]>;
+
+	/**
+	 * List metadata (total count, pagination, etc).
+	 */
+	listMeta: Record<
+		string,
+		{
+			total?: number;
+			hasMore?: boolean;
+			nextCursor?: string;
+		}
+	>;
+
+	/**
+	 * Error messages by cache key.
+	 */
+	errors: Record<string, string>;
+}
+
+/**
+ * Actions for a resource store.
+ *
+ * @template T - The resource entity type
+ */
+export interface ResourceActions<T> {
+	/**
+	 * Receive a single item.
+	 *
+	 * @param item - The item to store
+	 */
+	receiveItem: (item: T) => void;
+
+	/**
+	 * Receive multiple items from a list query.
+	 *
+	 * @param queryKey - Stringified query parameters
+	 * @param items    - Array of items
+	 * @param meta     - List metadata (total, hasMore, nextCursor)
+	 */
+	receiveItems: (
+		queryKey: string,
+		items: T[],
+		meta?: {
+			total?: number;
+			hasMore?: boolean;
+			nextCursor?: string;
+		}
+	) => void;
+
+	/**
+	 * Store an error for a given cache key.
+	 *
+	 * @param cacheKey - The cache key that failed
+	 * @param error    - Error message
+	 */
+	receiveError: (cacheKey: string, error: string) => void;
+
+	/**
+	 * Clear cached data for specific cache keys.
+	 *
+	 * @param cacheKeys - Array of cache keys to invalidate
+	 */
+	invalidate: (cacheKeys: string[]) => void;
+
+	/**
+	 * Clear all cached data for this resource.
+	 */
+	invalidateAll: () => void;
+}
+
+/**
+ * Selectors for a resource store.
+ *
+ * @template T - The resource entity type
+ * @template TQuery - The query parameter type for list operations
+ */
+export interface ResourceSelectors<T, TQuery = unknown> {
+	/**
+	 * Get a single item by ID.
+	 *
+	 * @param state - Store state
+	 * @param id    - Item ID
+	 * @return The item or undefined if not found
+	 */
+	getItem: (state: ResourceState<T>, id: string | number) => T | undefined;
+
+	/**
+	 * Get items from a list query.
+	 *
+	 * @param state - Store state
+	 * @param query - Query parameters
+	 * @return Array of items
+	 */
+	getItems: (state: ResourceState<T>, query?: TQuery) => T[];
+
+	/**
+	 * Get list response with metadata.
+	 *
+	 * @param state - Store state
+	 * @param query - Query parameters
+	 * @return List response with items and metadata
+	 */
+	getList: (state: ResourceState<T>, query?: TQuery) => ListResponse<T>;
+
+	/**
+	 * Check if a selector is currently resolving.
+	 *
+	 * Note: This is provided by @wordpress/data's resolution system.
+	 * We include it here for type completeness.
+	 *
+	 * @param state        - Store state
+	 * @param selectorName - Name of the selector
+	 * @param args         - Arguments passed to the selector
+	 * @return True if resolving
+	 */
+	isResolving: (
+		state: ResourceState<T>,
+		selectorName: string,
+		args?: unknown[]
+	) => boolean;
+
+	/**
+	 * Check if a selector has started resolution.
+	 *
+	 * Note: This is provided by @wordpress/data's resolution system.
+	 * We include it here for type completeness.
+	 *
+	 * @param state        - Store state
+	 * @param selectorName - Name of the selector
+	 * @param args         - Arguments passed to the selector
+	 * @return True if resolution has started
+	 */
+	hasStartedResolution: (
+		state: ResourceState<T>,
+		selectorName: string,
+		args?: unknown[]
+	) => boolean;
+
+	/**
+	 * Check if a selector has finished resolution.
+	 *
+	 * Note: This is provided by @wordpress/data's resolution system.
+	 * We include it here for type completeness.
+	 *
+	 * @param state        - Store state
+	 * @param selectorName - Name of the selector
+	 * @param args         - Arguments passed to the selector
+	 * @return True if resolution has finished
+	 */
+	hasFinishedResolution: (
+		state: ResourceState<T>,
+		selectorName: string,
+		args?: unknown[]
+	) => boolean;
+
+	/**
+	 * Get error for a cache key.
+	 *
+	 * @param state    - Store state
+	 * @param cacheKey - The cache key
+	 * @return Error message or undefined
+	 */
+	getError: (state: ResourceState<T>, cacheKey: string) => string | undefined;
+}
+
+/**
+ * Resolvers for a resource store.
+ *
+ * @template _T - The resource entity type (unused, for type inference in store creation)
+ * @template TQuery - The query parameter type for list operations
+ */
+export interface ResourceResolvers<_T, TQuery = unknown> {
+	/**
+	 * Resolver for getItem selector.
+	 * Fetches a single item by ID if not already in state.
+	 *
+	 * @param id - Item ID
+	 */
+	getItem: (id: string | number) => Promise<void>;
+
+	/**
+	 * Resolver for getItems selector.
+	 * Fetches a list of items if not already in state.
+	 *
+	 * @param query - Query parameters
+	 */
+	getItems: (query?: TQuery) => Promise<void>;
+
+	/**
+	 * Resolver for getList selector.
+	 * Same as getItems but includes metadata.
+	 *
+	 * @param query - Query parameters
+	 */
+	getList: (query?: TQuery) => Promise<void>;
+}
+
+/**
+ * Store configuration for a resource.
+ *
+ * @template T - The resource entity type
+ * @template TQuery - The query parameter type for list operations
+ */
+export interface ResourceStoreConfig<T, TQuery = unknown> {
+	/**
+	 * The resource object this store is for.
+	 */
+	resource: ResourceObject<T, TQuery>;
+
+	/**
+	 * Initial state for the store.
+	 */
+	initialState?: Partial<ResourceState<T>>;
+
+	/**
+	 * Function to extract ID from an item.
+	 * Defaults to (item) => item.id
+	 */
+	getId?: (item: T) => string | number;
+
+	/**
+	 * Function to generate query key from query params.
+	 * Defaults to JSON.stringify
+	 */
+	getQueryKey?: (query?: TQuery) => string;
+}
+
+/**
+ * Complete store descriptor returned by createStore.
+ *
+ * @template T - The resource entity type
+ * @template TQuery - The query parameter type for list operations
+ */
+export interface ResourceStore<T, TQuery = unknown> {
+	/**
+	 * Store key for registration with @wordpress/data.
+	 */
+	storeKey: string;
+
+	/**
+	 * State selectors.
+	 */
+	selectors: ResourceSelectors<T, TQuery>;
+
+	/**
+	 * State actions.
+	 */
+	actions: ResourceActions<T>;
+
+	/**
+	 * Resolvers for async data fetching.
+	 */
+	resolvers: ResourceResolvers<T, TQuery>;
+
+	/**
+	 * Reducer function for state updates.
+	 */
+	reducer: (
+		state: ResourceState<T> | undefined,
+		action: unknown
+	) => ResourceState<T>;
+
+	/**
+	 * Initial state.
+	 */
+	initialState: ResourceState<T>;
+}

--- a/packages/kernel/src/resource/types.ts
+++ b/packages/kernel/src/resource/types.ts
@@ -260,6 +260,10 @@ export interface ResourceClient<T = unknown, TQuery = unknown> {
  * // Use in store selectors
  * const storeKey = thing.storeKey; // 'gk/thing'
  *
+ * // Access @wordpress/data store (lazy-loaded, auto-registered)
+ * const store = thing.store;
+ * const item = select(store).getItem(123);
+ *
  * // Use cache keys for invalidation
  * invalidate(thing.cacheKeys.list({ q: 'search' }));
  * ```
@@ -277,6 +281,20 @@ export interface ResourceObject<T = unknown, TQuery = unknown>
 	 * Used for store registration and selectors
 	 */
 	storeKey: string;
+
+	/**
+	 * Lazy-loaded @wordpress/data store
+	 *
+	 * Automatically registered on first access.
+	 * Returns the store descriptor compatible with select/dispatch.
+	 *
+	 * @example
+	 * ```ts
+	 * import { select } from '@wordpress/data';
+	 * const item = select(thing.store).getItem(123);
+	 * ```
+	 */
+	readonly store: unknown; // Type is unknown because @wordpress/data types are complex
 
 	/**
 	 * Cache key generators for all operations


### PR DESCRIPTION
## Summary

Implements A3 from Sprint 1: @wordpress/data store integration for resources.

## What Changed

### Store Factory
- **`createStore()` factory** - Generates typed @wordpress/data stores from ResourceObject definitions
- **Automatic registration** - Stores auto-register with `window.wp.data` on first access via lazy getter
- **Complete Redux-like API** - Reducer, actions, selectors, and resolvers following @wordpress/data patterns

### Resource Integration
- **Lazy `store` property** - Added to ResourceObject for on-demand store creation
- **Zero configuration** - Stores automatically use resource name, routes, and cache keys
- **Seamless WordPress integration** - Works with @wordpress/data select/dispatch/useSelect APIs

### TypeScript Support
Full type safety with:
- `ResourceState<T>` - Normalized state shape
- `ResourceActions<T>` - Action creators
- `ResourceSelectors<T, TQuery>` - Data extraction functions
- `ResourceResolvers<T, TQuery>` - Async data fetching
- `ResourceStoreConfig<T, TQuery>` - Store configuration
- `ResourceStore<T, TQuery>` - Complete store descriptor

### Store Features
- **Selectors**: `getItem()`, `getItems()`, `getList()`, `getError()`, plus resolution helpers
- **Resolvers**: Automatic data fetching with error handling when selectors are used
- **Actions**: `receiveItem()`, `receiveItems()`, `receiveError()`, `invalidate()`, `invalidateAll()`
- **Reducer**: Immutable state updates with type guards for all action types
- **Customization**: Custom `getId` and `getQueryKey` functions, initial state support

## Testing

### New Tests
- **42 new test cases** total
  - 36 tests for createStore (all store functionality)
  - 6 tests for defineResource lazy store initialization

### Coverage Improvements
- **Overall coverage**: 91.6% → **94.8%** ✅
- **Store module**: **93.82%** coverage
- **defineResource**: 80% → **92.53%** (fixed coverage drop)
- **Total tests**: 195 passing

### Test Coverage
- Store creation with custom config
- Reducer handling all action types (RECEIVE_ITEM, RECEIVE_ITEMS, RECEIVE_ERROR, INVALIDATE, INVALIDATE_ALL)
- All action creators
- All selectors (getItem, getItems, getList, getError)
- Resolvers with error handling and NotImplementedError
- Custom getId/getQueryKey functions
- Lazy store initialization and singleton pattern
- window.wp.data registration scenarios

## Documentation

Added comprehensive @wordpress/data store integration section to `docs/guide/resources.md`:
- Accessing stores from resources
- Complete selector documentation with examples
- Resolver auto-fetch patterns
- Action usage for manual state updates
- Complete working examples with useSelect hooks
- Custom store configuration
- Best practices (4 key patterns)

## Version Changes

- **@geekist/wp-kernel**: 0.1.0 → 0.1.1
- **Root package.json**: 0.1.0 → 0.1.1
- **CHANGELOG.md**: Added detailed A3 section

## Quality Checks ✅

- ✅ TypeScript compilation (all 4 packages)
- ✅ All tests passing (195 tests, 7 suites)
- ✅ Linting passing (0 errors, 0 warnings)
- ✅ Coverage maintained above 90% threshold
- ✅ Pre-commit hooks passing (typecheck:tests, docs:build)

## Files Changed

### New Files
- `packages/kernel/src/resource/store/types.ts` (315 lines) - Store type definitions
- `packages/kernel/src/resource/store/createStore.ts` (352 lines) - Store factory implementation
- `packages/kernel/src/resource/store/index.ts` (16 lines) - Clean exports
- `packages/kernel/src/resource/store/__tests__/createStore.test.ts` (690 lines) - Comprehensive tests

### Modified Files
- `packages/kernel/src/resource/defineResource.ts` - Added lazy store getter
- `packages/kernel/src/resource/types.ts` - Added store property to ResourceObject
- `packages/kernel/src/resource/__tests__/defineResource.test.ts` - Added 6 store tests
- `packages/kernel/src/index.ts` - Exported createStore and store types
- `docs/guide/resources.md` - Added comprehensive store integration guide
- `package.json` - Version bump to 0.1.1
- `packages/kernel/package.json` - Version bump to 0.1.1
- `CHANGELOG.md` - Added A3 section

## Implementation Notes

- Store creation is **lazy** - only initialized on first `resource.store` access
- Stores automatically register with `window.wp.data.register()` when available (browser environment)
- Resolvers use **async functions** (not generators) for simpler implementation
- **Normalized state structure**: items by ID, lists as ID arrays, separate metadata
- Default `getId` assumes `item.id` property
- Default `getQueryKey` uses `JSON.stringify`

Closes #3
