### PR TITLE
C4: Fix Generated API Docs 404 Errors

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -78,15 +78,15 @@ export default defineConfig({
 					items: [
 						{
 							text: 'Resources',
-							link: '/api/generated/resource/',
+							link: '/api/generated/resource/README',
 						},
 						{
 							text: 'Errors',
-							link: '/api/generated/errors/',
+							link: '/api/generated/errors/README',
 						},
 						{
 							text: 'Transport',
-							link: '/api/generated/transport/',
+							link: '/api/generated/transport/README',
 						},
 					],
 				},

--- a/docs/api/generated/resource/functions/defineResource.md
+++ b/docs/api/generated/resource/functions/defineResource.md
@@ -10,7 +10,7 @@
 function defineResource<T, TQuery>(config): ResourceObject<T, TQuery>;
 ```
 
-Defined in: [resource/defineResource.ts:348](https://github.com/theGeekist/wp-kernel/blob/main/packages/kernel/src/resource/defineResource.ts#L348)
+Defined in: [resource/defineResource.ts:339](https://github.com/theGeekist/wp-kernel/blob/main/packages/kernel/src/resource/defineResource.ts#L339)
 
 Define a resource with typed REST client
 


### PR DESCRIPTION
## Summary

Fixes 404 errors on generated API documentation paths by updating VitePress sidebar configuration.

## Problem

Generated API docs at paths like:
- 
- 
- 

Were returning 404 on GitHub Pages.

## Root Cause

TypeDoc-plugin-markdown generates  files, which VitePress converts to  instead of . When accessing a directory URL on GitHub Pages, it looks for  by default, not .

## Solution

Updated VitePress config sidebar links to point explicitly to  instead of . VitePress preview server handles both formats, and this ensures GitHub Pages can resolve the correct file.

## Testing

✅ Local build verified
✅ VitePress preview server confirms pages load correctly
✅ Pre-commit hooks passed (typecheck + docs build)

## Closes

Closes #14

## Sprint

Sprint 1 - C4: CI & Docs Hooks (final fix for generated docs deployment)