### PR TITLE
[pkg] finalize unified reporting and data helpers

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,6 +12,14 @@ Define typed REST resources with automatic client generation, store integration,
 
 Declarative capability rules with caching, denial events, and React helpers for UI gating.
 
+### [Reporter](/api/reporter)
+
+Structured logging via LogLayer with console and WordPress hook transports.
+
+### [Data Helpers](/guide/data)
+
+Registry utilities (`useKernel`, `registerKernelStore`) and notice bridging for `@wordpress/data` stores.
+
 ### [Errors](/api/generated/error/README)
 
 Error types and handling primitives.

--- a/docs/api/reporter.md
+++ b/docs/api/reporter.md
@@ -1,0 +1,77 @@
+# Reporter
+
+The reporter module provides a unified logging surface for the kernel. It routes structured log entries through LogLayer so that
+console output, WordPress hooks, and future transports share the same formatting and namespace metadata.
+
+## Import
+
+```typescript
+import { createReporter } from '@geekist/wp-kernel/reporter';
+```
+
+## `createReporter(options)`
+
+Creates a reporter instance scoped to a namespace. Reporters expose levelled methods (`info`, `warn`, `error`, `debug`) plus
+`child()` for composing nested namespaces.
+
+```typescript
+const reporter = createReporter({ namespace: 'kernel', channel: 'all' });
+
+reporter.info('Action started', { requestId: 'act_123' });
+reporter.error('Policy denied', { rule: 'posts.delete' });
+```
+
+### Options
+
+| Option      | Type                                        | Default   | Description                                                            |
+| ----------- | ------------------------------------------- | --------- | ---------------------------------------------------------------------- |
+| `namespace` | `string`                                    | `kernel`  | Prefix for log lines and hook names (`{namespace}.reporter.{level}`).  |
+| `channel`   | `'console' \| 'hooks' \| 'bridge' \| 'all'` | `console` | Transport selection. Bridge is reserved for the PHP bridge (post-4.5). |
+| `level`     | `'debug' \| 'info' \| 'warn' \| 'error'`    | `info`    | Minimum log level processed by transports.                             |
+| `enabled`   | `boolean`                                   | `true`    | Disable all transports without changing configuration.                 |
+
+### Methods
+
+| Method  | Signature                                      | Notes                                                   |
+| ------- | ---------------------------------------------- | ------------------------------------------------------- |
+| `info`  | `(message: string, context?: unknown) => void` | Emits informational log entry.                          |
+| `warn`  | `(message: string, context?: unknown) => void` | Emits warning-level entry.                              |
+| `error` | `(message: string, context?: unknown) => void` | Emits error entry and is ideal for surfaced failures.   |
+| `debug` | `(message: string, context?: unknown) => void` | Emits debug entry (honours `level`).                    |
+| `child` | `(namespace: string) => Reporter`              | Returns a reporter nested under `{parent}.{namespace}`. |
+
+Context objects are passed through LogLayer metadata. They remain structured when the entry is sent to hooks or console.
+
+### Transports
+
+Sprint 4.5 ships two transports with unified formatting:
+
+- **Console** – writes `[namespace] message` to the developer console (skipped in production builds).
+- **Hooks** – emits `doAction('{namespace}.reporter.{level}', { message, context, timestamp })`.
+
+The bridge transport is reserved for the PHP integration in a later sprint. Requesting it throws to highlight the missing
+implementation.
+
+### Child Reporters
+
+Use `child()` to create scoped reporters without repeating configuration:
+
+```typescript
+const kernelReporter = createReporter({
+	namespace: 'showcase',
+	channel: 'all',
+});
+const policyReporter = kernelReporter.child('policy');
+
+policyReporter.warn('Rule denied', { rule: 'posts.delete' });
+// Hook: showcase.policy.reporter.warn
+```
+
+## Integration
+
+- **Actions** – the kernel automatically creates a reporter per namespace when actions execute.
+- **Policies** – `definePolicy()` uses a reporter when `debug: true` is provided.
+- **Registry** – `useKernel()` accepts a reporter override when wiring `@wordpress/data`.
+
+Every console call inside `packages/kernel/src` now routes through this module. The custom ESLint rule
+`@kernel/no-console-in-kernel` enforces the policy.

--- a/docs/contributing/standards.md
+++ b/docs/contributing/standards.md
@@ -219,6 +219,9 @@ Extends `@wordpress/eslint-plugin`:
 }
 ```
 
+Kernel packages ship custom rules. Notably, `@kernel/no-console-in-kernel` forbids `console.*` calls inside
+`packages/kernel/src`-use the reporter module instead.
+
 ### Prettier
 
 ```json

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -211,6 +211,12 @@ export const CreatePost = defineAction(
 );
 ```
 
+### Reporting and notices
+
+`ctx.reporter` forwards structured telemetry to the reporter module. With `channel: 'all'` the message prints in development
+consoles and emits `showcase.reporter.error` via `wp.hooks`. When paired with [`useKernel()`](/guide/data) the
+`kernelEventsPlugin()` listens for `wpk.action.error` and raises `core/notices` alerts automatically.
+
 ## Using Actions in Your UI
 
 Once you have an action, using it is simple and consistent:

--- a/docs/guide/data.md
+++ b/docs/guide/data.md
@@ -1,0 +1,71 @@
+# WordPress Data Integration
+
+The kernel now ships first-class helpers for wiring actions into `@wordpress/data`. The goal is to make registries aware of
+actions, errors, and notices without duplicating glue code in every plugin.
+
+## `useKernel(registry, options)`
+
+Registers kernel middleware and plugins against an existing data registry. It returns a cleanup function you can call when
+tearing down tests or hot reloading modules.
+
+```typescript
+import { createRegistry } from '@wordpress/data';
+import { useKernel } from '@geekist/wp-kernel/data';
+import { createReporter } from '@geekist/wp-kernel/reporter';
+
+const registry = createRegistry();
+const teardown = useKernel(registry, {
+	namespace: 'showcase',
+	reporter: createReporter({ namespace: 'showcase', channel: 'all' }),
+});
+```
+
+### Options
+
+| Option       | Type                | Description                                                           |
+| ------------ | ------------------- | --------------------------------------------------------------------- |
+| `namespace`  | `string`            | Overrides the namespace detected from globals.                        |
+| `reporter`   | `Reporter`          | Custom reporter instance; defaults to a kernel-scoped reporter.       |
+| `middleware` | `ReduxMiddleware[]` | Additional Redux middleware appended after the kernel action handler. |
+
+The helper installs two kernel pieces:
+
+1. **Action middleware** – intercepts envelopes produced by `invokeAction()` and executes defined actions.
+2. **Events plugin** – listens for `wpk.action.error` events and dispatches notices via the registry while logging through the
+   reporter.
+
+Cleanup removes both middleware registrations and unsubscribes the hook listener.
+
+## `kernelEventsPlugin`
+
+You rarely call this directly; `useKernel()` wires it in automatically. The plugin bridges action failures to `core/notices` and
+structured logging. Hook listeners receive payloads with `message`, `context`, and `timestamp` so WordPress plugins can subscribe
+to `wpk.action.error` without reverse engineering the payload.
+
+## `registerKernelStore(key, config)`
+
+A convenience wrapper around `createReduxStore` and `register`:
+
+```typescript
+import { registerKernelStore } from '@geekist/wp-kernel/data';
+
+export const store = registerKernelStore('acme/posts', {
+	reducer: postsReducer,
+	actions: postsActions,
+	selectors: postsSelectors,
+	resolvers: postsResolvers,
+});
+```
+
+It returns the store descriptor produced by `createReduxStore`, making it compatible with existing WordPress patterns. Use this
+helper when defining stores within a kernel-powered plugin-the registry middleware from `useKernel()` will automatically pick up
+kernel actions dispatched through the store.
+
+## Putting it together
+
+1. Define stores with `registerKernelStore()`.
+2. Register the kernel middleware once per registry with `useKernel()`.
+3. Dispatch actions through `invokeAction()` envelopes-errors become notices and the reporter receives structured context.
+
+The end result is parity with Redux integrations while keeping all error reporting, logging, and capability enforcement inside
+the kernel.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -61,6 +61,14 @@ Actions are the only sanctioned write path. They call resources, wrap permission
 
 Events publish what happened in language the rest of the platform understands. Names follow `wpk.{domain}.{verb}` and remain stable across major versions. Extensions listen to them, telemetry records them, and the PHP bridge mirrors a curated subset for legacy integrations. [Read the full guide →](/guide/events)
 
+### Reporting
+
+Reporters centralise logging, route errors to `core/notices`, and expose hook-friendly payloads for observability. [Read the full guide →](/guide/reporting)
+
+### WordPress data integration
+
+Helpers for wiring kernel middleware into `@wordpress/data` registries and stores, including automatic notice bridging. [Read the full guide →](/guide/data)
+
 ### Block bindings
 
 Bindings connect WordPress blocks to your data. Instead of hard-coded `InnerBlocks` or custom blocks, you register sources that map store selectors to block attributes. Editors and front-end users see consistent content without juggling bespoke APIs. [Read the full guide →](/guide/block-bindings)

--- a/docs/guide/reporting.md
+++ b/docs/guide/reporting.md
@@ -1,0 +1,95 @@
+# Reporting & Observability
+
+Sprint 4.5 introduces a unified reporter so every kernel module emits structured telemetry through LogLayer. Instead of
+sprinkling `console.log` calls across the codebase, you now create reporters and route messages through transports that understand
+namespaces, levels, and context metadata.
+
+## Why reporters?
+
+- **Single source of truth** – Actions, policies, and registry plugins rely on the same transport configuration.
+- **Structured payloads** – Hooks receive `{ message, context, timestamp }` so downstream consumers stay typed.
+- **Environment aware** – Console logging is skipped in production, while hooks remain active for instrumentation.
+- **Lint enforcement** – The `@kernel/no-console-in-kernel` rule blocks accidental `console.*` usage in core code.
+
+## Creating a reporter
+
+```typescript
+import { createReporter } from '@geekist/wp-kernel/reporter';
+
+const reporter = createReporter({ namespace: 'showcase', channel: 'all' });
+
+reporter.info('Action started', { requestId: 'act_42' });
+reporter.error('Save failed', { error });
+```
+
+- **`namespace`** controls the prefix for console output and the hook name (`showcase.reporter.error`).
+- **`channel`** chooses transports. Use `'all'` to enable both console and WordPress hooks.
+- **`child()`** lets you create nested reporters without redefining options.
+
+## In actions
+
+The action runtime automatically provisions a reporter scoped to the detected namespace. You can call `ctx.reporter.*`
+inside your action implementations:
+
+```typescript
+async function CreatePost(ctx, input) {
+	ctx.reporter.debug('Creating post', { input });
+	try {
+		const post = await postResource.create(input);
+		ctx.reporter.info('Post created', { postId: post.id });
+		return post;
+	} catch (error) {
+		ctx.reporter.error('Post creation failed', { error });
+		throw error;
+	}
+}
+```
+
+When an action throws, the reporter also feeds the `kernelEventsPlugin()` bridge so failures show up as `core/notices` alerts.
+
+## In policies
+
+`definePolicy()` now accepts `debug: true` to enable reporter output. The reporter shares the same namespace so hook listeners can
+correlate events across the stack:
+
+```typescript
+const policy = definePolicy(rules, {
+	namespace: 'showcase',
+	debug: true,
+});
+```
+
+Without `debug`, the policy reporter becomes a no-op and avoids console noise.
+
+## Registry integration
+
+The new `useKernel()` helper wires kernel middleware into an `@wordpress/data` registry:
+
+```typescript
+import { useKernel } from '@geekist/wp-kernel/data';
+
+const registry = createRegistry();
+const teardown = useKernel(registry, {
+	namespace: 'showcase',
+	reporter: createReporter({ namespace: 'showcase', channel: 'all' }),
+});
+```
+
+- Installs the action middleware so dispatched envelopes execute kernel actions.
+- Registers the events plugin which converts `wpk.action.error` into `core/notices` entries and logs via the reporter.
+- Accepts additional middleware through the `middleware` option.
+
+Call the returned cleanup function when hot reloading or tearing down tests to remove middleware and hook listeners.
+
+## Linting: no console in kernel
+
+`console.*` calls are forbidden in `packages/kernel/src` outside the reporter module. Use the reporter everywhere else. The ESLint
+rule runs automatically, so commits that bypass the reporter will fail linting.
+
+## Migration tips
+
+- Replace `console.log('[wp-kernel]', msg)` with `reporter.info(msg)`.
+- When porting legacy modules, create a scoped reporter and pass it down instead of injecting raw console objects.
+- To debug locally without polluting logs, use `child()` to create granular namespaces (`kernel.debug.imports`).
+
+By routing logs through the reporter you get consistent formatting, hook emission, and future bridge support for free.

--- a/eslint-rules/no-console-in-kernel.js
+++ b/eslint-rules/no-console-in-kernel.js
@@ -1,0 +1,44 @@
+import path from 'path';
+
+const SRC_SEGMENT = path.join('packages', 'kernel', 'src');
+const ALLOWED_SEGMENTS = [path.join('packages', 'kernel', 'src', 'reporter')];
+
+export default {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow console usage in kernel core; use reporter instead.',
+			recommended: false,
+		},
+		messages: {
+			noConsole:
+				'Use the reporter module instead of console. kernel core code must not call console APIs directly.',
+		},
+		schema: [],
+	},
+
+	create(context) {
+		const filename = context.getFilename();
+		if (!filename.includes(SRC_SEGMENT)) {
+			return {};
+		}
+
+		if (ALLOWED_SEGMENTS.some((segment) => filename.includes(segment))) {
+			return {};
+		}
+
+		if (filename.includes('__tests__')) {
+			return {};
+		}
+
+		return {
+			"MemberExpression[object.name='console']"(node) {
+				context.report({
+					node,
+					messageId: 'noConsole',
+				});
+			},
+		};
+	},
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,9 +13,17 @@ import globals from 'globals';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import noManualTestGlobals from './eslint-rules/no-manual-test-globals.js';
+import noConsoleInKernel from './eslint-rules/no-console-in-kernel.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const kernelPlugin = {
+	rules: {
+		'no-manual-test-globals': noManualTestGlobals,
+		'no-console-in-kernel': noConsoleInKernel,
+	},
+};
 
 const compat = new FlatCompat({
 	baseDirectory: __dirname,
@@ -70,6 +78,10 @@ export default [
 			},
 		},
 
+		plugins: {
+			'@kernel': kernelPlugin,
+		},
+
 		// Custom rules for WP Kernel
 		rules: {
 			// Disable problematic rule (ESLint 9 compatibility issue)
@@ -107,9 +119,12 @@ export default [
 						'^@wordpress/',
 						'^@kernel/',
 						'^@geekist/wp-kernel',
+						'^@loglayer/',
 					],
 				},
 			],
+
+			'@kernel/no-console-in-kernel': 'error',
 		},
 	},
 
@@ -172,11 +187,7 @@ export default [
 			'**/__tests__/**',
 		],
 		plugins: {
-			'@kernel': {
-				rules: {
-					'no-manual-test-globals': noManualTestGlobals,
-				},
-			},
+			'@kernel': kernelPlugin,
 		},
 		rules: {
 			'no-console': 'off',

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -52,6 +52,16 @@
 			"import": "./dist/actions/index.js",
 			"default": "./dist/actions/index.js"
 		},
+		"./data": {
+			"types": "./dist/data/index.d.ts",
+			"import": "./dist/data/index.js",
+			"default": "./dist/data/index.js"
+		},
+		"./reporter": {
+			"types": "./dist/reporter/index.d.ts",
+			"import": "./dist/reporter/index.js",
+			"default": "./dist/reporter/index.js"
+		},
 		"./package.json": "./package.json"
 	},
 	"files": [
@@ -81,5 +91,10 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"dependencies": {
+		"@loglayer/shared": "^2.4.0",
+		"@loglayer/transport": "^2.3.0",
+		"loglayer": "^6.7.2"
 	}
 }

--- a/packages/kernel/src/actions/__tests__/defineAction.test.ts
+++ b/packages/kernel/src/actions/__tests__/defineAction.test.ts
@@ -28,6 +28,7 @@ describe('defineAction', () => {
 				warn: jest.fn(),
 				error: jest.fn(),
 				debug: jest.fn(),
+				child: jest.fn(),
 			},
 			policy: {
 				assert: jest.fn(),

--- a/packages/kernel/src/actions/types.ts
+++ b/packages/kernel/src/actions/types.ts
@@ -16,6 +16,15 @@
 
 import type { CacheKeyPattern } from '../resource/cache';
 import type { PolicyHelpers } from '../policy/types';
+import type { Reporter } from '../reporter';
+
+/**
+ * Structured logging interface for action observability.
+ *
+ * Provided by the reporter module to ensure a single source of truth for
+ * transports and formatting while keeping the public type available here.
+ */
+export type { Reporter } from '../reporter';
 
 /**
  * Configuration options controlling action event propagation and bridging.
@@ -54,35 +63,6 @@ export interface ActionOptions {
 export interface ResolvedActionOptions {
 	scope: 'crossTab' | 'tabLocal';
 	bridged: boolean;
-}
-
-/**
- * Structured logging interface for action observability.
- *
- * The reporter provides standardized logging methods that actions can use for
- * telemetry, debugging, and error tracking. Host applications can inject custom
- * reporters to route logs to external observability tools (Sentry, Datadog, etc.).
- *
- * @example
- * ```typescript
- * async function CreatePost(ctx, input) {
- *   ctx.reporter.info('Creating post', { input });
- *   try {
- *     const post = await api.posts.create(input);
- *     ctx.reporter.debug('Post created', { postId: post.id });
- *     return post;
- *   } catch (err) {
- *     ctx.reporter.error('Post creation failed', { error: err });
- *     throw err;
- *   }
- * }
- * ```
- */
-export interface Reporter {
-	info: (message: string, context?: Record<string, unknown>) => void;
-	warn: (message: string, context?: Record<string, unknown>) => void;
-	error: (message: string, context?: Record<string, unknown>) => void;
-	debug?: (message: string, context?: Record<string, unknown>) => void;
 }
 
 /**

--- a/packages/kernel/src/data/__tests__/kernelEventsPlugin.test.ts
+++ b/packages/kernel/src/data/__tests__/kernelEventsPlugin.test.ts
@@ -1,0 +1,168 @@
+import type { ActionErrorEvent } from '../../actions/types';
+import { KernelError } from '../../error/KernelError';
+import { kernelEventsPlugin } from '../plugins/events';
+import type { Reporter } from '../../reporter';
+import type { KernelRegistry } from '../types';
+
+function createRegistryMock(): KernelRegistry & { createNotice: jest.Mock } {
+	const createNotice = jest.fn();
+	const dispatch = jest.fn().mockReturnValue({ createNotice });
+	return {
+		dispatch,
+		createNotice,
+	} as unknown as KernelRegistry & { createNotice: jest.Mock };
+}
+
+describe('kernelEventsPlugin', () => {
+	beforeEach(() => {
+		(window.wp?.hooks?.addAction as jest.Mock | undefined)?.mockReset?.();
+		(
+			window.wp?.hooks?.removeAction as jest.Mock | undefined
+		)?.mockReset?.();
+	});
+
+	it('dispatches notices and reports errors from action events', () => {
+		const registry = createRegistryMock();
+		const reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn(),
+		} as jest.Mocked<Reporter>;
+		reporter.child.mockReturnValue(reporter);
+
+		let eventHandler: ((event: ActionErrorEvent) => void) | undefined;
+		const addAction = window.wp?.hooks?.addAction as jest.Mock;
+		addAction.mockImplementation((hookName, _namespace, handler) => {
+			if (hookName === 'wpk.action.error') {
+				eventHandler = handler as (event: ActionErrorEvent) => void;
+			}
+		});
+
+		const middleware = kernelEventsPlugin({
+			reporter,
+			registry,
+		});
+
+		const next = jest.fn();
+		middleware({ dispatch: jest.fn(), getState: jest.fn() })(next)({
+			type: 'IGNORE',
+		});
+
+		const error = new Error('Network failed');
+		eventHandler?.({
+			error,
+			actionName: 'CreatePost',
+			requestId: 'act_123',
+			namespace: 'acme',
+			phase: 'error',
+			durationMs: 25,
+			scope: 'crossTab',
+			bridged: true,
+			timestamp: Date.now(),
+		} as ActionErrorEvent);
+
+		expect(registry.createNotice).toHaveBeenCalledWith(
+			'error',
+			'Network failed',
+			expect.objectContaining({ id: 'act_123', isDismissible: true })
+		);
+		expect(reporter.error).toHaveBeenCalledWith('Network failed', {
+			action: 'CreatePost',
+			namespace: 'acme',
+			requestId: 'act_123',
+			status: 'error',
+		});
+
+		middleware.destroy?.();
+		expect(window.wp?.hooks?.removeAction).toHaveBeenCalledWith(
+			'wpk.action.error',
+			'kernel/notices'
+		);
+	});
+
+	it('maps KernelError codes to notice statuses', () => {
+		const registry = createRegistryMock();
+		const reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn(),
+		} as jest.Mocked<Reporter>;
+		reporter.child.mockReturnValue(reporter);
+
+		const addAction = window.wp?.hooks?.addAction as jest.Mock;
+		let eventHandler: ((event: ActionErrorEvent) => void) | undefined;
+		addAction.mockImplementation((hookName, _namespace, handler) => {
+			if (hookName === 'wpk.action.error') {
+				eventHandler = handler as (event: ActionErrorEvent) => void;
+			}
+		});
+
+		const middleware = kernelEventsPlugin({ reporter, registry });
+		middleware({ dispatch: jest.fn(), getState: jest.fn() })(jest.fn())({
+			type: 'IGNORE',
+		});
+
+		eventHandler?.({
+			error: new KernelError('PolicyDenied', { message: 'denied' }),
+			actionName: 'CheckPolicy',
+			requestId: 'act_warning',
+			namespace: 'acme',
+			phase: 'error',
+			durationMs: 5,
+			scope: 'crossTab',
+			bridged: true,
+			timestamp: Date.now(),
+		} as ActionErrorEvent);
+
+		expect(registry.createNotice).toHaveBeenNthCalledWith(
+			1,
+			'warning',
+			'denied',
+			expect.objectContaining({ id: 'act_warning' })
+		);
+
+		eventHandler?.({
+			error: new KernelError('ValidationError', { message: 'invalid' }),
+			actionName: 'Validate',
+			requestId: 'act_info',
+			namespace: 'acme',
+			phase: 'error',
+			durationMs: 5,
+			scope: 'crossTab',
+			bridged: true,
+			timestamp: Date.now(),
+		} as ActionErrorEvent);
+
+		expect(registry.createNotice).toHaveBeenNthCalledWith(
+			2,
+			'info',
+			'invalid',
+			expect.objectContaining({ id: 'act_info' })
+		);
+
+		eventHandler?.({
+			error: 'string failure',
+			actionName: 'StringError',
+			requestId: 'act_string',
+			namespace: 'acme',
+			phase: 'error',
+			durationMs: 5,
+			scope: 'crossTab',
+			bridged: true,
+			timestamp: Date.now(),
+		} as ActionErrorEvent);
+
+		expect(registry.createNotice).toHaveBeenNthCalledWith(
+			3,
+			'error',
+			'string failure',
+			expect.objectContaining({ id: 'act_string' })
+		);
+
+		middleware.destroy?.();
+	});
+});

--- a/packages/kernel/src/data/__tests__/useKernel.test.ts
+++ b/packages/kernel/src/data/__tests__/useKernel.test.ts
@@ -1,0 +1,82 @@
+import type { ReduxMiddleware } from '../../actions/types';
+import type { Reporter } from '../../reporter';
+import { useKernel } from '../registry';
+import type { KernelRegistry } from '../types';
+
+describe('useKernel', () => {
+	beforeEach(() => {
+		(window.wp?.hooks?.addAction as jest.Mock | undefined)?.mockReset?.();
+		(
+			window.wp?.hooks?.removeAction as jest.Mock | undefined
+		)?.mockReset?.();
+	});
+
+	it('installs kernel middleware and returns cleanup handler', () => {
+		const detachAction = jest.fn();
+		const detachEvents = jest.fn();
+		const registry = {
+			__experimentalUseMiddleware: jest
+				.fn()
+				.mockReturnValueOnce(detachAction)
+				.mockReturnValueOnce(detachEvents),
+			dispatch: jest.fn().mockReturnValue({ createNotice: jest.fn() }),
+		} as unknown as KernelRegistry & {
+			__experimentalUseMiddleware: jest.Mock;
+		};
+
+		const reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn(),
+		} as jest.Mocked<Reporter>;
+		reporter.child.mockReturnValue(reporter);
+		const customMiddleware: ReduxMiddleware = () => (next) => (action) =>
+			next(action);
+
+		const cleanup = useKernel(registry, {
+			reporter,
+			middleware: [customMiddleware],
+			namespace: 'acme',
+		});
+
+		expect(registry.__experimentalUseMiddleware).toHaveBeenCalledTimes(2);
+
+		const actionMiddlewareFactory =
+			registry.__experimentalUseMiddleware.mock.calls[0][0];
+		const middlewares = actionMiddlewareFactory();
+		expect(Array.isArray(middlewares)).toBe(true);
+		expect(middlewares).toHaveLength(2);
+		expect(middlewares[1]).toBe(customMiddleware);
+
+		const eventsMiddlewareFactory =
+			registry.__experimentalUseMiddleware.mock.calls[1][0];
+		const [eventsMiddleware] = eventsMiddlewareFactory();
+		const next = jest.fn();
+		eventsMiddleware({ dispatch: jest.fn(), getState: jest.fn() })(next)({
+			type: 'PING',
+		});
+		expect(window.wp?.hooks?.addAction).toHaveBeenCalledWith(
+			'wpk.action.error',
+			'kernel/notices',
+			expect.any(Function)
+		);
+
+		cleanup();
+
+		expect(detachAction).toHaveBeenCalled();
+		expect(detachEvents).toHaveBeenCalled();
+		expect(window.wp?.hooks?.removeAction).toHaveBeenCalledWith(
+			'wpk.action.error',
+			'kernel/notices'
+		);
+	});
+
+	it('returns noop when registry does not support middleware', () => {
+		const registry = {} as unknown as KernelRegistry;
+
+		const cleanup = useKernel(registry);
+		expect(cleanup()).toBeUndefined();
+	});
+});

--- a/packages/kernel/src/data/index.ts
+++ b/packages/kernel/src/data/index.ts
@@ -1,0 +1,5 @@
+export { useKernel } from './registry';
+export { registerKernelStore } from './store';
+export type { KernelRegistryOptions } from './registry';
+export type { NoticeStatus, KernelEventsPluginOptions } from './plugins/events';
+export type { KernelRegistry } from './types';

--- a/packages/kernel/src/data/plugins/events.ts
+++ b/packages/kernel/src/data/plugins/events.ts
@@ -1,0 +1,140 @@
+import { KernelError } from '../../error/KernelError';
+import type { ActionErrorEvent, ReduxMiddleware } from '../../actions/types';
+import type { Reporter } from '../../reporter';
+import type { KernelRegistry } from '../types';
+
+export type NoticeStatus = 'success' | 'info' | 'warning' | 'error';
+
+export interface KernelEventsPluginOptions {
+	reporter?: Reporter;
+	registry?: KernelRegistry;
+}
+
+interface NoticesDispatch {
+	createNotice: (
+		status: NoticeStatus,
+		content: string,
+		options?: Record<string, unknown>
+	) => void;
+}
+
+type WordPressHooks = {
+	addAction?: (
+		hookName: string,
+		namespace: string,
+		callback: (payload: ActionErrorEvent) => void,
+		priority?: number
+	) => void;
+	removeAction?: (hookName: string, namespace: string) => void;
+};
+
+interface KernelReduxMiddleware<TState = unknown>
+	extends ReduxMiddleware<TState> {
+	destroy?: () => void;
+}
+
+function getHooks(): WordPressHooks | null {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	const wp = (window as Window & { wp?: { hooks?: WordPressHooks } }).wp;
+	return wp?.hooks ?? null;
+}
+
+function getNoticesDispatch(
+	registry: KernelRegistry | undefined
+): NoticesDispatch | null {
+	if (!registry || typeof registry.dispatch !== 'function') {
+		return null;
+	}
+
+	try {
+		const dispatch = registry.dispatch('core/notices') as unknown;
+		if (
+			!dispatch ||
+			typeof (dispatch as NoticesDispatch).createNotice !== 'function'
+		) {
+			return null;
+		}
+		return dispatch as NoticesDispatch;
+	} catch (_error) {
+		return null;
+	}
+}
+
+function mapErrorToStatus(error: unknown): NoticeStatus {
+	if (KernelError.isKernelError(error)) {
+		switch (error.code) {
+			case 'PolicyDenied':
+				return 'warning';
+			case 'ValidationError':
+				return 'info';
+			default:
+				return 'error';
+		}
+	}
+
+	return 'error';
+}
+
+function resolveErrorMessage(error: unknown): string {
+	if (KernelError.isKernelError(error)) {
+		return error.message;
+	}
+
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	if (typeof error === 'string') {
+		return error;
+	}
+
+	return 'An unexpected error occurred';
+}
+
+export function kernelEventsPlugin({
+	reporter,
+	registry,
+}: KernelEventsPluginOptions): KernelReduxMiddleware {
+	const hooks = getHooks();
+	const notices = getNoticesDispatch(registry);
+	const pluginNamespace = 'kernel/notices';
+
+	let detach: (() => void) | undefined;
+
+	const middleware: KernelReduxMiddleware = () => {
+		if (hooks?.addAction) {
+			const handler = (event: ActionErrorEvent) => {
+				const message = resolveErrorMessage(event.error);
+				const status = mapErrorToStatus(event.error);
+
+				notices?.createNotice(status, message, {
+					id: event.requestId,
+					isDismissible: true,
+				});
+
+				reporter?.error(message, {
+					action: event.actionName,
+					requestId: event.requestId,
+					namespace: event.namespace,
+					status,
+				});
+			};
+
+			hooks.addAction('wpk.action.error', pluginNamespace, handler);
+			detach = () =>
+				hooks.removeAction?.('wpk.action.error', pluginNamespace);
+		}
+
+		return (next) => (action) => next(action);
+	};
+
+	middleware.destroy = () => {
+		detach?.();
+		detach = undefined;
+	};
+
+	return middleware;
+}

--- a/packages/kernel/src/data/registry.ts
+++ b/packages/kernel/src/data/registry.ts
@@ -1,0 +1,58 @@
+import { createActionMiddleware } from '../actions/middleware';
+import type { ReduxMiddleware } from '../actions/types';
+import { getNamespace } from '../namespace/detect';
+import { createReporter } from '../reporter';
+import type { Reporter } from '../reporter';
+import { kernelEventsPlugin } from './plugins/events';
+import type { KernelRegistry } from './types';
+
+export interface KernelRegistryOptions {
+	middleware?: ReduxMiddleware[];
+	reporter?: Reporter;
+	namespace?: string;
+}
+
+export function useKernel(
+	registry: KernelRegistry,
+	options: KernelRegistryOptions = {}
+): () => void {
+	const applyMiddleware = registry.__experimentalUseMiddleware;
+	if (typeof applyMiddleware !== 'function') {
+		return () => undefined;
+	}
+
+	const namespace = options.namespace ?? getNamespace();
+	const reporter =
+		options.reporter ??
+		createReporter({ namespace, channel: 'all', level: 'debug' });
+
+	const cleanupTasks: Array<() => void> = [];
+
+	const actionMiddleware = createActionMiddleware();
+	const detachAction = applyMiddleware(() => [
+		actionMiddleware,
+		...(options.middleware ?? []),
+	]);
+	if (typeof detachAction === 'function') {
+		cleanupTasks.push(detachAction);
+	}
+
+	const eventsMiddleware = kernelEventsPlugin({
+		reporter,
+		registry,
+	});
+	const detachEvents = applyMiddleware(() => [eventsMiddleware]);
+	cleanupTasks.push(() => {
+		if (typeof detachEvents === 'function') {
+			detachEvents();
+		}
+		eventsMiddleware.destroy?.();
+	});
+
+	return () => {
+		while (cleanupTasks.length > 0) {
+			const task = cleanupTasks.pop();
+			task?.();
+		}
+	};
+}

--- a/packages/kernel/src/data/store.ts
+++ b/packages/kernel/src/data/store.ts
@@ -1,0 +1,15 @@
+import { createReduxStore, register } from '@wordpress/data';
+
+export function registerKernelStore<
+	Key extends string,
+	State,
+	Actions extends Record<string, (...args: unknown[]) => unknown>,
+	Selectors,
+>(
+	key: Key,
+	config: Parameters<typeof createReduxStore<State, Actions, Selectors>>[1]
+) {
+	const store = createReduxStore<State, Actions, Selectors>(key, config);
+	register(store);
+	return store;
+}

--- a/packages/kernel/src/data/types.ts
+++ b/packages/kernel/src/data/types.ts
@@ -1,0 +1,9 @@
+import type { WPDataRegistry } from '@wordpress/data/build-types/registry';
+import type { ReduxMiddleware } from '../actions/types';
+
+export type KernelRegistry = WPDataRegistry & {
+	__experimentalUseMiddleware?: (
+		middleware: () => ReduxMiddleware[]
+	) => (() => void) | void;
+	dispatch: (storeName: string) => unknown;
+};

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -54,6 +54,7 @@ export * as error from './error/index.js';
 export * as namespace from './namespace/index.js';
 export * as actions from './actions/index.js';
 export * as policy from './policy/index.js';
+export * as data from './data/index.js';
 
 // ============================================================================
 // Flat Exports (Convenience aliases)
@@ -134,7 +135,6 @@ export type {
 	ActionErrorEvent,
 	DefinedAction,
 	ResolvedActionOptions,
-	Reporter,
 	ActionJobs,
 	WaitOptions,
 } from './actions/types';
@@ -154,6 +154,18 @@ export type {
 	UsePolicyResult,
 	ParamsOf,
 } from './policy/index.js';
+
+// Data integration
+export { useKernel, registerKernelStore } from './data/index.js';
+export type { KernelRegistryOptions, NoticeStatus } from './data/index.js';
+
+// Reporter
+export { createReporter, createNoopReporter } from './reporter/index.js';
+export type {
+	Reporter,
+	ReporterOptions,
+	ReporterLevel,
+} from './reporter/index.js';
 
 // Namespace detection
 export {

--- a/packages/kernel/src/namespace/detect.ts
+++ b/packages/kernel/src/namespace/detect.ts
@@ -1,3 +1,5 @@
+import { createReporter } from '../reporter';
+
 /**
  * Namespace Detection Module
  *
@@ -61,6 +63,12 @@ const RESERVED_NAMESPACES = [
 	'www',
 ] as const;
 
+const namespaceReporter = createReporter({
+	namespace: 'kernel.namespace',
+	channel: 'all',
+	level: 'warn',
+});
+
 /**
  * Check if we're in development mode
  * @return True if in development environment
@@ -89,11 +97,11 @@ function emitDevWarning(source: string, namespace: string): void {
 	}
 
 	if (source === 'fallback') {
-		console.warn(
+		namespaceReporter.warn(
 			`🔧 WP Kernel: Using fallback namespace "${namespace}". For deterministic behavior, set __WPK_NAMESPACE__ (build-time) or wpKernelData.textDomain (runtime). See: https://github.com/theGeekist/wp-kernel/docs/namespace-detection`
 		);
 	} else if (source === 'package-json') {
-		console.warn(
+		namespaceReporter.warn(
 			`📦 WP Kernel: Using package.json name for namespace "${namespace}". For WordPress-native behavior, set wpKernelData.textDomain or __WPK_NAMESPACE__. See: https://github.com/theGeekist/wp-kernel/docs/namespace-detection`
 		);
 	}

--- a/packages/kernel/src/policy/__tests__/cache.test.ts
+++ b/packages/kernel/src/policy/__tests__/cache.test.ts
@@ -97,9 +97,11 @@ describe('createPolicyCache', () => {
 		const cache = createPolicyCache({ storage: 'session' }, 'acme');
 		expect(cache.keys()).toEqual([]);
 		expect(warn).toHaveBeenCalledWith(
+			'[kernel.policy.cache]',
 			'[wp-kernel] Failed to parse persisted policy cache.',
 			expect.any(SyntaxError)
 		);
+		expect(console as any).toHaveWarned();
 	});
 
 	it('persists values and surfaces storage errors', () => {
@@ -129,9 +131,11 @@ describe('createPolicyCache', () => {
 			.mockImplementation(() => undefined);
 		cache.set('policy::void', false);
 		expect(warn).toHaveBeenCalledWith(
+			'[kernel.policy.cache]',
 			'[wp-kernel] Failed to persist policy cache.',
 			error
 		);
+		expect(console as any).toHaveWarned();
 	});
 
 	it('handles session storage access failures gracefully', () => {
@@ -148,9 +152,11 @@ describe('createPolicyCache', () => {
 		const cache = createPolicyCache({ storage: 'session' }, 'acme');
 		expect(cache.keys()).toEqual([]);
 		expect(warn).toHaveBeenCalledWith(
+			'[kernel.policy.cache]',
 			'[wp-kernel] sessionStorage is not available for policy cache.',
 			expect.any(Error)
 		);
+		expect(console as any).toHaveWarned();
 	});
 
 	it('evicts expired entries based on ttl', () => {
@@ -275,9 +281,11 @@ describe('createPolicyCache', () => {
 			.mockImplementation(() => undefined);
 		const cache = createPolicyCache({}, 'acme');
 		expect(warn).toHaveBeenCalledWith(
+			'[kernel.policy.cache]',
 			'[wp-kernel] Failed to create BroadcastChannel for policy cache.',
 			expect.any(Error)
 		);
+		expect(console as any).toHaveWarned();
 		cache.set('policy::void', true);
 	});
 

--- a/packages/kernel/src/policy/__tests__/define.behavior.test.ts
+++ b/packages/kernel/src/policy/__tests__/define.behavior.test.ts
@@ -82,9 +82,11 @@ describe('definePolicy behaviour', () => {
 			expect(outcome).toBe(false);
 		}
 		expect(warn).toHaveBeenCalledWith(
-			'[wp-kernel][policy] Failed to invoke wp.data.select("core").canUser',
+			'[wpk]',
+			'Failed to invoke wp.data.select("core").canUser',
 			expect.objectContaining({ error: expect.any(Error) })
 		);
+		expect(console as any).toHaveWarned();
 		select!.mockReset();
 	});
 
@@ -265,9 +267,11 @@ describe('definePolicy behaviour', () => {
 			expect((error as { code?: string }).code).toBe('PolicyDenied');
 		}
 		expect(warn).toHaveBeenCalledWith(
+			'[kernel.policy]',
 			'[wp-kernel] Failed to create BroadcastChannel for policy events.',
-			expect.any(Error)
+			{ error: expect.any(Error) }
 		);
+		expect(console as any).toHaveWarned();
 	});
 
 	it('warns when extending an existing policy key', async () => {
@@ -280,7 +284,10 @@ describe('definePolicy behaviour', () => {
 
 		policy.extend({ allow: () => false });
 		expect(warn).toHaveBeenCalledWith(
-			'Policy "allow" is being overridden via extend().'
+			'[kernel.policy]',
+			'Policy "allow" is being overridden via extend().',
+			{ policyKey: 'allow' }
 		);
+		expect(console as any).toHaveWarned();
 	});
 });

--- a/packages/kernel/src/policy/__tests__/define.environment.test.ts
+++ b/packages/kernel/src/policy/__tests__/define.environment.test.ts
@@ -75,13 +75,17 @@ describe('policy environment edge cases', () => {
 
 		expect(broadcastSpy).toHaveBeenCalled();
 		expect(warnSpy).toHaveBeenCalledWith(
+			'[kernel.policy.cache]',
 			'[wp-kernel] Failed to create BroadcastChannel for policy cache.',
 			broadcastError
 		);
+		expect(console as any).toHaveWarned();
 		expect(warnSpy).toHaveBeenCalledWith(
+			'[kernel.policy]',
 			'[wp-kernel] Failed to create BroadcastChannel for policy events.',
-			broadcastError
+			{ error: broadcastError }
 		);
+		expect(console as any).toHaveWarned();
 		warnSpy.mockRestore();
 	});
 
@@ -134,11 +138,13 @@ describe('policy environment edge cases', () => {
 			});
 
 			expect(warnSpy).toHaveBeenCalledWith(
-				'[wp-kernel][policy] Failed to invoke wp.data.select("core").canUser',
+				'[acme]',
+				'Failed to invoke wp.data.select("core").canUser',
 				{
 					error: failure,
 				}
 			);
+			expect(console as any).toHaveWarned();
 		});
 		warnSpy.mockRestore();
 	});
@@ -290,16 +296,16 @@ describe('policy environment edge cases', () => {
 			expect(policy.can('tasks.reporter')).toBe(true);
 		});
 
-		expect(infoSpy).toHaveBeenCalledWith('[wp-kernel][policy] inform', {
+		expect(infoSpy).toHaveBeenCalledWith('[wpk]', 'inform', {
 			id: 1,
 		});
-		expect(warnSpy).toHaveBeenCalledWith('[wp-kernel][policy] warn', {
+		expect(warnSpy).toHaveBeenCalledWith('[wpk]', 'warn', {
 			id: 2,
 		});
-		expect(errorSpy).toHaveBeenCalledWith('[wp-kernel][policy] error', {
+		expect(errorSpy).toHaveBeenCalledWith('[wpk]', 'error', {
 			id: 3,
 		});
-		expect(debugSpy).toHaveBeenCalledWith('[wp-kernel][policy] debug', {
+		expect(debugSpy).toHaveBeenCalledWith('[wpk]', 'debug', {
 			id: 4,
 		});
 		infoSpy.mockRestore();

--- a/packages/kernel/src/policy/cache.ts
+++ b/packages/kernel/src/policy/cache.ts
@@ -15,11 +15,18 @@
  */
 
 import { getNamespace } from '../namespace/detect';
+import { createReporter } from '../reporter';
 import type { PolicyCache, PolicyCacheOptions } from './types';
 
 const DEFAULT_TTL_MS = 60_000;
 const STORAGE_KEY_PREFIX = 'wpk.policy.cache';
 const BROADCAST_CHANNEL_NAME = 'wpk.policy.cache';
+
+const policyCacheReporter = createReporter({
+	namespace: 'kernel.policy.cache',
+	channel: 'console',
+	level: 'warn',
+});
 
 type Listener = () => void;
 
@@ -112,7 +119,7 @@ function getStorage(options: PolicyCacheOptions | undefined): Storage | null {
 		try {
 			return window.sessionStorage;
 		} catch (error) {
-			console.warn(
+			policyCacheReporter.warn(
 				'[wp-kernel] sessionStorage is not available for policy cache.',
 				error
 			);
@@ -145,7 +152,7 @@ function readPersisted(
 		}
 		return parsed;
 	} catch (error) {
-		console.warn(
+		policyCacheReporter.warn(
 			'[wp-kernel] Failed to parse persisted policy cache.',
 			error
 		);
@@ -167,7 +174,10 @@ function persist(
 		const serialized = JSON.stringify(Object.fromEntries(store.entries()));
 		storage.setItem(`${STORAGE_KEY_PREFIX}.${namespace}`, serialized);
 	} catch (error) {
-		console.warn('[wp-kernel] Failed to persist policy cache.', error);
+		policyCacheReporter.warn(
+			'[wp-kernel] Failed to persist policy cache.',
+			error
+		);
 	}
 }
 
@@ -189,7 +199,7 @@ function createBroadcastChannel(
 	try {
 		return new window.BroadcastChannel(BROADCAST_CHANNEL_NAME);
 	} catch (error) {
-		console.warn(
+		policyCacheReporter.warn(
 			'[wp-kernel] Failed to create BroadcastChannel for policy cache.',
 			error
 		);

--- a/packages/kernel/src/policy/context.ts
+++ b/packages/kernel/src/policy/context.ts
@@ -16,6 +16,7 @@
 
 import { KernelError } from '../error/KernelError';
 import type { ActionRuntime } from '../actions/types';
+import { createReporter } from '../reporter';
 import type { PolicyHelpers } from './types';
 
 export interface PolicyProxyOptions {
@@ -29,6 +30,11 @@ export interface PolicyProxyOptions {
 type PolicyRequestContext = PolicyProxyOptions;
 
 let currentContext: PolicyRequestContext | undefined;
+const policyContextReporter = createReporter({
+	namespace: 'kernel.policy',
+	channel: 'console',
+	level: 'warn',
+});
 
 export function getPolicyRuntime(): ActionRuntime | undefined {
 	return globalThis.__WP_KERNEL_ACTION_RUNTIME__;
@@ -147,7 +153,7 @@ export function createPolicyProxy(
 			const runtimePolicy = getPolicyRuntime()?.policy;
 			if (!runtimePolicy?.can) {
 				if (!warned && process.env.NODE_ENV !== 'production') {
-					console.warn(
+					policyContextReporter.warn(
 						`Action "${options.actionName}" called policy.can('${key}') but no policy runtime is configured.`
 					);
 					warned = true;

--- a/packages/kernel/src/policy/types.ts
+++ b/packages/kernel/src/policy/types.ts
@@ -16,17 +16,15 @@
  * @module @geekist/wp-kernel/policy/types
  */
 
+import type { Reporter } from '../reporter';
+
 /**
  * Reporter interface used for structured diagnostics from the policy runtime.
- * Mirrors the reporter surface used by actions but is defined locally to avoid
- * circular type dependencies.
+ *
+ * Aliased from the shared reporter module to ensure policy and actions emit
+ * consistent log metadata.
  */
-export interface PolicyReporter {
-	info: (message: string, context?: Record<string, unknown>) => void;
-	warn: (message: string, context?: Record<string, unknown>) => void;
-	error: (message: string, context?: Record<string, unknown>) => void;
-	debug?: (message: string, context?: Record<string, unknown>) => void;
-}
+export type PolicyReporter = Reporter;
 
 /**
  * Policy rule signature.

--- a/packages/kernel/src/reporter/__tests__/createReporter.test.ts
+++ b/packages/kernel/src/reporter/__tests__/createReporter.test.ts
@@ -1,0 +1,96 @@
+import { createReporter } from '../index';
+
+describe('createReporter', () => {
+	const originalInfo = console.info;
+	const originalWarn = console.warn;
+	const originalError = console.error;
+	const originalDebug = console.debug;
+
+	beforeEach(() => {
+		console.info = jest.fn();
+		console.warn = jest.fn();
+		console.error = jest.fn();
+		console.debug = jest.fn();
+		(window.wp?.hooks?.doAction as jest.Mock | undefined)?.mockReset?.();
+	});
+
+	afterEach(() => {
+		console.info = originalInfo;
+		console.warn = originalWarn;
+		console.error = originalError;
+		console.debug = originalDebug;
+	});
+
+	it('logs to console transport when info is invoked', () => {
+		const reporter = createReporter({
+			namespace: 'test',
+			channel: 'console',
+			level: 'debug',
+		});
+
+		reporter.info('hello world', { source: 'unit-test' });
+		reporter.warn('warn message');
+		reporter.error('error message');
+		reporter.debug('debug message');
+
+		expect(console.info).toHaveBeenCalledWith('[test]', 'hello world', {
+			source: 'unit-test',
+		});
+		expect(console.warn).toHaveBeenCalledWith('[test]', 'warn message');
+		expect(console.error).toHaveBeenCalledWith('[test]', 'error message');
+		expect(console.debug).toHaveBeenCalledWith('[test]', 'debug message');
+
+		expect(console as any).toHaveInformedWith('[test]', 'hello world', {
+			source: 'unit-test',
+		});
+		expect(console as any).toHaveWarnedWith('[test]', 'warn message');
+		expect(console as any).toHaveErroredWith('[test]', 'error message');
+	});
+
+	it('emits WordPress hooks when hooks channel is selected', () => {
+		const reporter = createReporter({
+			namespace: 'acme',
+			channel: 'hooks',
+		});
+
+		reporter.error('failed to save', { retry: true });
+
+		const doAction = window.wp?.hooks?.doAction as jest.Mock | undefined;
+		expect(doAction).toHaveBeenCalledWith(
+			'acme.reporter.error',
+			expect.objectContaining({
+				message: 'failed to save',
+				context: { retry: true },
+			})
+		);
+	});
+
+	it('supports child reporters with nested namespaces', () => {
+		const reporter = createReporter({
+			namespace: 'kernel',
+			channel: 'console',
+		});
+		const child = reporter.child('policy');
+
+		child.warn('denied');
+
+		expect(console.warn).toHaveBeenCalledWith('[kernel.policy]', 'denied');
+	});
+
+	it('respects enabled=false by skipping transports', () => {
+		const reporter = createReporter({
+			namespace: 'disabled',
+			enabled: false,
+		});
+
+		reporter.info('ignored');
+
+		expect(console.info).not.toHaveBeenCalled();
+	});
+
+	it('throws for unsupported bridge channel', () => {
+		expect(() => createReporter({ channel: 'bridge' })).toThrow(
+			'Bridge transport is planned for a future sprint'
+		);
+	});
+});

--- a/packages/kernel/src/reporter/index.ts
+++ b/packages/kernel/src/reporter/index.ts
@@ -1,0 +1,116 @@
+import { LogLayer } from 'loglayer';
+import type { LogLevelType } from '@loglayer/shared';
+import { createTransports } from './transports';
+import type { Reporter, ReporterLevel, ReporterOptions } from './types';
+
+const DEFAULT_NAMESPACE = 'kernel';
+const DEFAULT_CHANNEL = 'console';
+const DEFAULT_LEVEL: ReporterLevel = 'info';
+
+function mapLevelToLogLevel(level: ReporterLevel): LogLevelType {
+	switch (level) {
+		case 'debug':
+			return 'debug';
+		case 'warn':
+			return 'warn';
+		case 'error':
+			return 'error';
+		case 'info':
+		default:
+			return 'info';
+	}
+}
+
+function logWithLevel(
+	logger: LogLayer,
+	level: ReporterLevel,
+	message: string,
+	context?: unknown
+): void {
+	const target =
+		typeof context === 'undefined'
+			? logger
+			: logger.withMetadata({ context });
+
+	switch (level) {
+		case 'debug':
+			target.debug(message);
+			break;
+		case 'warn':
+			target.warn(message);
+			break;
+		case 'error':
+			target.error(message);
+			break;
+		case 'info':
+		default:
+			target.info(message);
+			break;
+	}
+}
+
+export function createReporter(options: ReporterOptions = {}): Reporter {
+	const namespace = options.namespace ?? DEFAULT_NAMESPACE;
+	const level = options.level ?? DEFAULT_LEVEL;
+	const channel = options.channel ?? DEFAULT_CHANNEL;
+	const enabled = options.enabled ?? true;
+
+	const transports = createTransports(channel, mapLevelToLogLevel(level));
+	const logger = new LogLayer({
+		transport: transports,
+	});
+
+	logger.withContext({ namespace });
+
+	if (!enabled) {
+		logger.disableLogging();
+	}
+
+	const report = (
+		entryLevel: ReporterLevel,
+		message: string,
+		context?: unknown
+	) => {
+		if (!enabled) {
+			return;
+		}
+
+		logWithLevel(logger, entryLevel, message, context);
+	};
+
+	const reporter: Reporter = {
+		info(message, context) {
+			report('info', message, context);
+		},
+		warn(message, context) {
+			report('warn', message, context);
+		},
+		error(message, context) {
+			report('error', message, context);
+		},
+		debug(message, context) {
+			report('debug', message, context);
+		},
+		child(childNamespace: string) {
+			const nextNamespace = `${namespace}.${childNamespace}`;
+			return createReporter({
+				...options,
+				namespace: nextNamespace,
+			});
+		},
+	};
+
+	return reporter;
+}
+
+export function createNoopReporter(): Reporter {
+	return {
+		info: () => undefined,
+		warn: () => undefined,
+		error: () => undefined,
+		debug: () => undefined,
+		child: () => createNoopReporter(),
+	};
+}
+
+export type { Reporter, ReporterOptions, ReporterLevel } from './types';

--- a/packages/kernel/src/reporter/transports.ts
+++ b/packages/kernel/src/reporter/transports.ts
@@ -1,0 +1,178 @@
+import { LoggerlessTransport } from '@loglayer/transport';
+import type {
+	LogLayerTransport,
+	LogLayerTransportParams,
+} from '@loglayer/transport';
+import type { LogLevelType } from '@loglayer/shared';
+import type {
+	ReporterChannel,
+	ReporterLevel,
+	ReporterLogMetadata,
+} from './types';
+
+function isReporterLevel(level: LogLevelType): level is ReporterLevel {
+	return (
+		level === 'debug' ||
+		level === 'info' ||
+		level === 'warn' ||
+		level === 'error'
+	);
+}
+
+function resolveNamespace(
+	context: Record<string, unknown> | undefined
+): string {
+	const candidate = context?.namespace;
+	return typeof candidate === 'string' && candidate.length > 0
+		? candidate
+		: 'kernel';
+}
+
+function parseMetadata(
+	params: LogLayerTransportParams
+): ReporterLogMetadata | null {
+	if (!isReporterLevel(params.logLevel)) {
+		return null;
+	}
+
+	const namespace = resolveNamespace(
+		(params.context as Record<string, unknown> | undefined) ?? undefined
+	);
+	const [message] = params.messages as [string?, ...unknown[]];
+	if (typeof message !== 'string') {
+		return null;
+	}
+
+	const metadata = params.metadata as { context?: unknown } | undefined;
+
+	return {
+		namespace,
+		level: params.logLevel,
+		message,
+		context: metadata?.context,
+		timestamp: Date.now(),
+	};
+}
+
+function getConsoleMethod(level: ReporterLevel) {
+	switch (level) {
+		case 'error':
+			return console.error.bind(console);
+		case 'warn':
+			return console.warn.bind(console);
+		case 'debug':
+			return console.debug.bind(console);
+		case 'info':
+		default:
+			return console.info.bind(console);
+	}
+}
+
+type WordPressHooks = {
+	doAction: (eventName: string, payload: unknown) => void;
+};
+
+function getHooks(): WordPressHooks | null {
+	if (typeof window === 'undefined') {
+		return null;
+	}
+
+	const wp = (window as Window & { wp?: { hooks?: WordPressHooks } }).wp;
+	if (!wp?.hooks || typeof wp.hooks.doAction !== 'function') {
+		return null;
+	}
+
+	return wp.hooks;
+}
+
+class ConsoleTransport extends LoggerlessTransport {
+	private readonly enabledByEnvironment: boolean;
+
+	public constructor(level: LogLevelType) {
+		const environmentEnabled = resolveEnvironmentEnabled();
+		super({
+			id: 'console',
+			level,
+			enabled: environmentEnabled,
+		});
+
+		this.enabledByEnvironment = environmentEnabled;
+	}
+
+	public override shipToLogger(params: LogLayerTransportParams): unknown[] {
+		if (!this.enabledByEnvironment) {
+			return [];
+		}
+
+		const entry = parseMetadata(params);
+		if (!entry) {
+			return [];
+		}
+
+		const emit = getConsoleMethod(entry.level);
+		const args: unknown[] = [`[${entry.namespace}]`, entry.message];
+		if (typeof entry.context !== 'undefined') {
+			args.push(entry.context);
+		}
+
+		emit(...args);
+		return args;
+	}
+}
+
+class HooksTransport extends LoggerlessTransport {
+	public constructor(level: LogLevelType) {
+		super({ id: 'hooks', level, enabled: true });
+	}
+
+	public override shipToLogger(params: LogLayerTransportParams): unknown[] {
+		const entry = parseMetadata(params);
+		if (!entry) {
+			return [];
+		}
+
+		const hooks = getHooks();
+		if (!hooks?.doAction) {
+			return [];
+		}
+
+		const payload = {
+			message: entry.message,
+			context: entry.context,
+			timestamp: entry.timestamp,
+		};
+		hooks.doAction(`${entry.namespace}.reporter.${entry.level}`, payload);
+		return [payload];
+	}
+}
+
+function resolveEnvironmentEnabled(): boolean {
+	if (typeof process === 'undefined' || !process.env) {
+		return true;
+	}
+
+	const env = process.env.NODE_ENV;
+	if (!env) {
+		return true;
+	}
+
+	return env !== 'production';
+}
+
+export function createTransports(
+	channel: ReporterChannel,
+	level: LogLevelType
+): LogLayerTransport | LogLayerTransport[] {
+	switch (channel) {
+		case 'console':
+			return new ConsoleTransport(level);
+		case 'hooks':
+			return new HooksTransport(level);
+		case 'all':
+			return [new ConsoleTransport(level), new HooksTransport(level)];
+		case 'bridge':
+			throw new Error('Bridge transport is planned for a future sprint');
+		default:
+			return new ConsoleTransport(level);
+	}
+}

--- a/packages/kernel/src/reporter/types.ts
+++ b/packages/kernel/src/reporter/types.ts
@@ -1,0 +1,30 @@
+export type ReporterChannel = 'console' | 'hooks' | 'bridge' | 'all';
+
+export type ReporterLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface ReporterOptions {
+	namespace?: string;
+	channel?: ReporterChannel;
+	level?: ReporterLevel;
+	/**
+	 * Enables or disables the reporter instance without changing transport configuration.
+	 * Primarily used for conditional debug reporters.
+	 */
+	enabled?: boolean;
+}
+
+export interface ReporterLogMetadata {
+	namespace: string;
+	level: ReporterLevel;
+	message: string;
+	context?: unknown;
+	timestamp: number;
+}
+
+export interface Reporter {
+	info: (message: string, context?: unknown) => void;
+	warn: (message: string, context?: unknown) => void;
+	error: (message: string, context?: unknown) => void;
+	debug: (message: string, context?: unknown) => void;
+	child: (namespace: string) => Reporter;
+}

--- a/packages/kernel/src/resource/__tests__/cache/edge-cases.test.ts
+++ b/packages/kernel/src/resource/__tests__/cache/edge-cases.test.ts
@@ -94,10 +94,10 @@ describe('invalidate edge cases', () => {
 			}).not.toThrow();
 
 			expect(consoleWarnSpy).toHaveBeenCalledWith(
-				expect.stringContaining(
-					'does not expose __getInternalState selector'
-				)
+				'[kernel.cache]',
+				'Store wpk/thing does not expose __getInternalState selector'
 			);
+			expect(console as any).toHaveWarned();
 		});
 
 		it('should log warning when invalidateAll fails in development', () => {
@@ -117,9 +117,11 @@ describe('invalidate edge cases', () => {
 			}).not.toThrow();
 
 			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'[kernel.cache]',
 				expect.stringContaining('Failed to invalidate all caches'),
 				expect.any(Error)
 			);
+			expect(console as any).toHaveWarned();
 		});
 
 		it('should not log warning when invalidate fails in production', () => {

--- a/packages/kernel/src/resource/__tests__/cache/invalidate.test.ts
+++ b/packages/kernel/src/resource/__tests__/cache/invalidate.test.ts
@@ -643,9 +643,11 @@ describe('invalidate', () => {
 
 			// Should log warning in development
 			expect(consoleWarnSpy).toHaveBeenCalledWith(
+				'[kernel.cache]',
 				expect.stringContaining('Failed to invalidate cache for store'),
 				expect.any(Error)
 			);
+			expect(console as any).toHaveWarned();
 
 			consoleWarnSpy.mockRestore();
 			process.env.NODE_ENV = originalEnv;

--- a/packages/kernel/src/resource/cache.ts
+++ b/packages/kernel/src/resource/cache.ts
@@ -1,3 +1,5 @@
+import { createReporter } from '../reporter';
+
 /**
  * Internal state shape exposed by the __getInternalState selector.
  * Mirrors reducer slices we care about for invalidation.
@@ -23,6 +25,12 @@ interface DispatchWithInvalidate {
  * Accepts a single pattern or an array of patterns.
  * @param patterns
  */
+const cacheReporter = createReporter({
+	namespace: 'kernel.cache',
+	channel: 'console',
+	level: 'warn',
+});
+
 function toPatternsArray(
 	patterns: CacheKeyPattern | CacheKeyPattern[]
 ): CacheKeyPattern[] {
@@ -194,7 +202,7 @@ function processStoreInvalidation(
 	const getInternalState = getInternalStateSelector(dataRegistry, storeKey);
 	if (!getInternalState) {
 		if (process.env.NODE_ENV === 'development') {
-			console.warn(
+			cacheReporter.warn(
 				`Store ${storeKey} does not expose __getInternalState selector`
 			);
 		}
@@ -578,7 +586,7 @@ export function invalidate(
 			);
 		} catch (error) {
 			if (process.env.NODE_ENV === 'development') {
-				console.warn(
+				cacheReporter.warn(
 					`Failed to invalidate cache for store ${key}:`,
 					error
 				);
@@ -649,7 +657,7 @@ export function invalidateAll(storeKey: string): void {
 		}
 	} catch (error) {
 		if (process.env.NODE_ENV === 'development') {
-			console.warn(
+			cacheReporter.warn(
 				`Failed to invalidate all caches for store ${storeKey}:`,
 				error
 			);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,12 @@ importers:
 
   packages/kernel:
     dependencies:
+      '@loglayer/shared':
+        specifier: ^2.4.0
+        version: 2.4.0
+      '@loglayer/transport':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@wordpress/api-fetch':
         specifier: '>=7.0.0'
         version: 7.31.0
@@ -246,6 +252,9 @@ importers:
       '@wordpress/hooks':
         specifier: '>=4.0.0'
         version: 4.31.0
+      loglayer:
+        specifier: ^6.7.2
+        version: 6.7.2
 
   packages/ui:
     dependencies:

--- a/tests/test-globals.d.ts
+++ b/tests/test-globals.d.ts
@@ -60,4 +60,13 @@ declare global {
 	 * @return WordPress data package or undefined if not available
 	 */
 	function getWPData(): typeof WPData | undefined;
+
+	namespace jest {
+		interface Matchers<R> {
+			toHaveWarned(): R;
+			toHaveWarnedWith(...expected: unknown[]): R;
+			toHaveErroredWith(...expected: unknown[]): R;
+			toHaveInformedWith(...expected: unknown[]): R;
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- add a LogLayer-backed reporter with console and WordPress hook transports plus unit coverage
- replace ad-hoc console usage with the shared reporter across actions, policies, and namespace detection
- introduce kernel data integration helpers, registry plugin wiring, and accompanying documentation updates

## Testing
- pnpm lint
- pnpm typecheck
- pnpm typecheck:tests
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e22adf92cc83258f1a99bffd3b3ab3