### PR TITLE
[pkg] expand integration coverage for reporter and data flows

### DIFF
--- a/packages/kernel/src/__tests__/integration/error-notifications-flow.test.ts
+++ b/packages/kernel/src/__tests__/integration/error-notifications-flow.test.ts
@@ -1,0 +1,177 @@
+import { KernelError } from '../../error/KernelError';
+import { createReporter } from '../../reporter';
+import { kernelEventsPlugin } from '../../data/plugins/events';
+import { registerKernelStore } from '../../data/store';
+import type { KernelRegistry } from '../../data/types';
+import { ensureWpData } from '@test-utils/wp';
+import type { ActionErrorEvent } from '../../actions/types';
+
+describe('Integration: Kernel error reporting flow', () => {
+	let createNotice: jest.Mock;
+	let recordedHooks: Record<string, unknown[]>;
+	let actionHandlers: Map<
+		string,
+		Map<string, (payload: ActionErrorEvent) => void>
+	>;
+	let originalConsoleError: typeof console.error;
+
+	beforeEach(() => {
+		const wpData = ensureWpData();
+		createNotice = jest.fn();
+		wpData.createReduxStore.mockReturnValue({
+			name: 'wpk/integration-store',
+		});
+		wpData.dispatch.mockImplementation((storeName: string) => {
+			if (storeName === 'core/notices') {
+				return { createNotice };
+			}
+			return {};
+		});
+
+		recordedHooks = {};
+		actionHandlers = new Map();
+
+		if (!window.wp?.hooks) {
+			throw new Error(
+				'window.wp.hooks not initialized for integration test'
+			);
+		}
+
+		window.wp.hooks.addAction = jest
+			.fn()
+			.mockImplementation(
+				(
+					hookName: string,
+					namespace: string,
+					handler: (payload: ActionErrorEvent) => void
+				) => {
+					const namespaceMap =
+						actionHandlers.get(hookName) ?? new Map();
+					namespaceMap.set(namespace, handler);
+					actionHandlers.set(hookName, namespaceMap);
+				}
+			);
+
+		window.wp.hooks.removeAction = jest
+			.fn()
+			.mockImplementation((hookName: string, namespace: string) => {
+				const namespaceMap = actionHandlers.get(hookName);
+				if (!namespaceMap) {
+					return;
+				}
+				namespaceMap.delete(namespace);
+				if (namespaceMap.size === 0) {
+					actionHandlers.delete(hookName);
+				}
+			});
+
+		window.wp.hooks.doAction = jest
+			.fn()
+			.mockImplementation((hookName: string, payload: unknown) => {
+				const namespaceMap = actionHandlers.get(hookName);
+				if (namespaceMap) {
+					namespaceMap.forEach((handler) =>
+						handler(payload as ActionErrorEvent)
+					);
+				}
+				(recordedHooks[hookName] ||= []).push(payload);
+			});
+
+		originalConsoleError = console.error;
+		console.error = jest.fn();
+	});
+
+	afterEach(() => {
+		console.error = originalConsoleError;
+		jest.restoreAllMocks();
+	});
+
+	it('creates notices and reporter output when action errors are emitted', () => {
+		const registry = ensureWpData() as unknown as KernelRegistry;
+
+		type IntegrationState = Record<string, never>;
+		type IntegrationActions = {
+			noop: () => void;
+		};
+		type IntegrationSelectors = {
+			selectNothing: () => undefined;
+		};
+
+		registerKernelStore<
+			'wpk/integration',
+			IntegrationState,
+			IntegrationActions,
+			IntegrationSelectors
+		>('wpk/integration', {
+			reducer: jest.fn(
+				(state: IntegrationState = {}, _action: unknown) => state
+			),
+			actions: {
+				noop: jest.fn(),
+			},
+			selectors: {
+				selectNothing: jest.fn(),
+			},
+		});
+
+		const reporter = createReporter({
+			namespace: 'integration',
+			channel: 'all',
+			level: 'info',
+		});
+
+		const middleware = kernelEventsPlugin({ reporter, registry });
+		const next = jest.fn();
+		middleware({ dispatch: jest.fn(), getState: jest.fn() })(next)({
+			type: 'INIT',
+		});
+
+		const event: ActionErrorEvent = {
+			error: new KernelError('ValidationError', {
+				message: 'Invalid input',
+			}),
+			actionName: 'SavePost',
+			requestId: 'req-123',
+			namespace: 'integration',
+			phase: 'error',
+			durationMs: 42,
+			scope: 'crossTab',
+			bridged: false,
+			timestamp: Date.now(),
+		};
+
+		window.wp?.hooks?.doAction?.('wpk.action.error', event);
+
+		expect(createNotice).toHaveBeenCalledWith(
+			'info',
+			'Invalid input',
+			expect.objectContaining({ id: 'req-123', isDismissible: true })
+		);
+
+		expect(console.error).toHaveBeenCalledWith(
+			'[integration]',
+			'Invalid input',
+			expect.objectContaining({
+				action: 'SavePost',
+				namespace: 'integration',
+				requestId: 'req-123',
+				status: 'info',
+			})
+		);
+		expect(recordedHooks['integration.reporter.error']).toEqual([
+			expect.objectContaining({
+				message: 'Invalid input',
+				context: expect.objectContaining({ status: 'info' }),
+			}),
+		]);
+
+		middleware.destroy?.();
+
+		window.wp?.hooks?.doAction?.('wpk.action.error', {
+			...event,
+			requestId: 'req-456',
+		});
+
+		expect(createNotice).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/kernel/src/__tests__/integration/error-notifications-flow.test.ts
+++ b/packages/kernel/src/__tests__/integration/error-notifications-flow.test.ts
@@ -6,6 +6,23 @@ import type { KernelRegistry } from '../../data/types';
 import { ensureWpData } from '@test-utils/wp';
 import type { ActionErrorEvent } from '../../actions/types';
 
+function createActionErrorEvent(
+	overrides: Partial<ActionErrorEvent> = {}
+): ActionErrorEvent {
+	return {
+		phase: 'error',
+		error: new KernelError('ValidationError', { message: 'test error' }),
+		actionName: 'TestAction',
+		requestId: 'test-req-id',
+		namespace: 'test',
+		durationMs: 10,
+		scope: 'crossTab',
+		bridged: false,
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
 describe('Integration: Kernel error reporting flow', () => {
 	let createNotice: jest.Mock;
 	let recordedHooks: Record<string, unknown[]>;
@@ -126,19 +143,15 @@ describe('Integration: Kernel error reporting flow', () => {
 			type: 'INIT',
 		});
 
-		const event: ActionErrorEvent = {
+		const event = createActionErrorEvent({
 			error: new KernelError('ValidationError', {
 				message: 'Invalid input',
 			}),
 			actionName: 'SavePost',
 			requestId: 'req-123',
 			namespace: 'integration',
-			phase: 'error',
 			durationMs: 42,
-			scope: 'crossTab',
-			bridged: false,
-			timestamp: Date.now(),
-		};
+		});
 
 		window.wp?.hooks?.doAction?.('wpk.action.error', event);
 

--- a/packages/kernel/src/data/__tests__/kernelEventsPlugin.test.ts
+++ b/packages/kernel/src/data/__tests__/kernelEventsPlugin.test.ts
@@ -202,4 +202,148 @@ describe('kernelEventsPlugin', () => {
 			expect(ns).toMatch(/^wpk\/notices\/\d+$/);
 		});
 	});
+
+	it('handles registries that cannot dispatch notices', () => {
+		const reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn(),
+		} as jest.Mocked<Reporter>;
+		reporter.child.mockReturnValue(reporter);
+
+		const addAction = window.wp?.hooks?.addAction as jest.Mock;
+		let eventHandler: ((event: ActionErrorEvent) => void) | undefined;
+		addAction.mockImplementation((hookName, _namespace, handler) => {
+			if (hookName === 'wpk.action.error') {
+				eventHandler = handler as (event: ActionErrorEvent) => void;
+			}
+		});
+
+		const middleware = kernelEventsPlugin({
+			reporter,
+			registry: undefined,
+		});
+
+		middleware({ dispatch: jest.fn(), getState: jest.fn() })(jest.fn())({
+			type: 'IGNORE',
+		});
+
+		eventHandler?.({
+			error: { reason: 'totally-unknown' },
+			actionName: 'UnknownAction',
+			requestId: 'fallback_1',
+			namespace: 'acme',
+			phase: 'error',
+			durationMs: 5,
+			scope: 'crossTab',
+			bridged: false,
+			timestamp: Date.now(),
+		} as ActionErrorEvent);
+
+		expect(reporter.error).toHaveBeenCalledWith(
+			'An unexpected error occurred',
+			expect.objectContaining({
+				action: 'UnknownAction',
+				requestId: 'fallback_1',
+				status: 'error',
+			})
+		);
+	});
+
+	it('swallows registry dispatch errors when notices cannot be resolved', () => {
+		const reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn(),
+		} as jest.Mocked<Reporter>;
+		reporter.child.mockReturnValue(reporter);
+
+		const dispatch = jest.fn(() => {
+			throw new Error('dispatch failed');
+		});
+
+		const registry = { dispatch } as unknown as KernelRegistry;
+
+		const addAction = window.wp?.hooks?.addAction as jest.Mock;
+		let eventHandler: ((event: ActionErrorEvent) => void) | undefined;
+		addAction.mockImplementation((hookName, _namespace, handler) => {
+			if (hookName === 'wpk.action.error') {
+				eventHandler = handler as (event: ActionErrorEvent) => void;
+			}
+		});
+
+		const middleware = kernelEventsPlugin({ reporter, registry });
+		middleware({ dispatch: jest.fn(), getState: jest.fn() })(jest.fn())({
+			type: 'IGNORE',
+		});
+
+		expect(() =>
+			eventHandler?.({
+				error: new KernelError('UnknownError', { message: 'uh oh' }),
+				actionName: 'FailingAction',
+				requestId: 'fallback_2',
+				namespace: 'acme',
+				phase: 'error',
+				durationMs: 12,
+				scope: 'crossTab',
+				bridged: false,
+				timestamp: Date.now(),
+			} as ActionErrorEvent)
+		).not.toThrow();
+
+		expect(dispatch).toHaveBeenCalledWith('core/notices');
+		expect(reporter.error).toHaveBeenCalledWith(
+			'uh oh',
+			expect.any(Object)
+		);
+	});
+
+	it('ignores registry responses without createNotice helpers', () => {
+		const reporter = {
+			info: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			debug: jest.fn(),
+			child: jest.fn(),
+		} as jest.Mocked<Reporter>;
+		reporter.child.mockReturnValue(reporter);
+
+		const dispatch = jest.fn().mockReturnValue({});
+		const registry = { dispatch } as unknown as KernelRegistry;
+
+		const addAction = window.wp?.hooks?.addAction as jest.Mock;
+		let eventHandler: ((event: ActionErrorEvent) => void) | undefined;
+		addAction.mockImplementation((hookName, _namespace, handler) => {
+			if (hookName === 'wpk.action.error') {
+				eventHandler = handler as (event: ActionErrorEvent) => void;
+			}
+		});
+
+		const middleware = kernelEventsPlugin({ reporter, registry });
+		middleware({ dispatch: jest.fn(), getState: jest.fn() })(jest.fn())({
+			type: 'IGNORE',
+		});
+
+		eventHandler?.({
+			error: new KernelError('PolicyDenied', { message: 'denied' }),
+			actionName: 'DeniedAction',
+			requestId: 'fallback_3',
+			namespace: 'acme',
+			phase: 'error',
+			durationMs: 8,
+			scope: 'crossTab',
+			bridged: true,
+			timestamp: Date.now(),
+		} as ActionErrorEvent);
+
+		expect(dispatch).toHaveBeenCalledWith('core/notices');
+		expect(reporter.error).toHaveBeenCalledWith(
+			'denied',
+			expect.any(Object)
+		);
+	});
 });

--- a/packages/kernel/src/data/__tests__/store.test.ts
+++ b/packages/kernel/src/data/__tests__/store.test.ts
@@ -1,0 +1,119 @@
+import { registerKernelStore } from '../store';
+import { ensureWpData } from '@test-utils/wp';
+
+type TestState = { value: number };
+
+type TestActions = {
+	increment: (...args: unknown[]) => TestAction;
+};
+
+type TestSelectors = {
+	getValue: (state: TestState) => number;
+};
+
+type TestAction = {
+	type: string;
+	payload?: unknown;
+};
+
+type TestStoreConfig = {
+	reducer: (state: TestState | undefined, action: TestAction) => TestState;
+	actions: TestActions;
+	selectors: TestSelectors;
+	resolvers?: Record<string, (...args: unknown[]) => unknown>;
+	controls?: Record<string, (...args: unknown[]) => unknown>;
+};
+
+jest.mock('@wordpress/data', () => ({
+	__esModule: true,
+	createReduxStore: (...args: unknown[]) =>
+		(window.wp?.data?.createReduxStore as jest.Mock | undefined)?.(...args),
+	register: (...args: unknown[]) =>
+		(window.wp?.data?.register as jest.Mock | undefined)?.(...args),
+}));
+
+describe('registerKernelStore', () => {
+	beforeEach(() => {
+		const wpData = ensureWpData();
+		wpData.createReduxStore.mockReset();
+		wpData.register.mockReset();
+	});
+
+	it('creates and registers the store with WordPress data registry', () => {
+		const wpData = ensureWpData();
+		const storeInstance = { name: 'wpk/test-store' };
+		wpData.createReduxStore.mockReturnValue(storeInstance);
+
+		const reducer: TestStoreConfig['reducer'] = (
+			state = { value: 0 },
+			action
+		) => {
+			if (action.type === 'SET') {
+				return { value: Number(action.payload) };
+			}
+			return state;
+		};
+		const actions: TestActions = {
+			increment: jest.fn((amount: unknown) => ({
+				type: 'SET',
+				payload: amount,
+			})),
+		};
+		const selectors: TestSelectors = {
+			getValue: jest.fn((state) => state.value),
+		};
+
+		const config: TestStoreConfig = {
+			reducer,
+			actions,
+			selectors,
+		};
+
+		const result = registerKernelStore('wpk/test', config);
+
+		expect(wpData.createReduxStore).toHaveBeenCalledWith(
+			'wpk/test',
+			config
+		);
+		expect(wpData.register).toHaveBeenCalledWith(storeInstance);
+		expect(result).toBe(storeInstance);
+	});
+
+	it('forwards configuration objects without modification', () => {
+		const wpData = ensureWpData();
+		const storeInstance = { name: 'wpk/forwarded-store' };
+		wpData.createReduxStore.mockReturnValue(storeInstance);
+
+		const config: TestStoreConfig = {
+			reducer: (state: TestState = { value: 0 }, action: TestAction) => {
+				if (action.type === 'SET') {
+					return { value: Number(action.payload) };
+				}
+				return state;
+			},
+			actions: {
+				increment: (...args: unknown[]) => ({
+					type: 'SET',
+					payload: args[0],
+				}),
+			},
+			selectors: {
+				getValue: (state: TestState) => state.value,
+			},
+			resolvers: {
+				resolveValue: jest.fn(),
+			},
+			controls: {
+				fetch: jest.fn(),
+			},
+		};
+
+		registerKernelStore('wpk/forwarded', config);
+
+		expect(wpData.createReduxStore).toHaveBeenCalledTimes(1);
+		expect(wpData.createReduxStore).toHaveBeenCalledWith(
+			'wpk/forwarded',
+			config
+		);
+	});
+});

--- a/packages/kernel/src/reporter/__tests__/transports.test.ts
+++ b/packages/kernel/src/reporter/__tests__/transports.test.ts
@@ -1,0 +1,208 @@
+import type { LogLayerTransportParams } from '@loglayer/transport';
+import { createTransports } from '../transports';
+import { WPK_NAMESPACE } from '../../namespace/constants';
+import { ensureWpData } from '@test-utils/wp';
+
+describe('reporter transports', () => {
+	const originalConsole = {
+		info: console.info,
+		warn: console.warn,
+		error: console.error,
+		debug: console.debug,
+	};
+	const originalEnv = process.env.NODE_ENV;
+
+	beforeEach(() => {
+		console.info = jest.fn();
+		console.warn = jest.fn();
+		console.error = jest.fn();
+		console.debug = jest.fn();
+
+		process.env.NODE_ENV = 'test';
+
+		const wpData = ensureWpData();
+		wpData.dispatch.mockReset();
+		wpData.register.mockReset();
+
+		if (window.wp?.hooks) {
+			window.wp.hooks.doAction = jest.fn();
+			window.wp.hooks.addAction = jest.fn();
+			window.wp.hooks.removeAction = jest.fn();
+		}
+	});
+
+	afterEach(() => {
+		console.info = originalConsole.info;
+		console.warn = originalConsole.warn;
+		console.error = originalConsole.error;
+		console.debug = originalConsole.debug;
+
+		process.env.NODE_ENV = originalEnv;
+		jest.restoreAllMocks();
+	});
+
+	function createParams(
+		overrides: Partial<LogLayerTransportParams> = {}
+	): LogLayerTransportParams {
+		return {
+			logLevel: 'info',
+			context: {},
+			messages: ['integration message'],
+			metadata: {},
+			...overrides,
+		} as LogLayerTransportParams;
+	}
+
+	it('disables console transport when running in production', () => {
+		process.env.NODE_ENV = 'production';
+
+		const transport = createTransports('console', 'info');
+		const params = createParams({
+			context: { namespace: 'acme' },
+			messages: ['should not log'],
+		});
+
+		const result = (
+			transport as {
+				shipToLogger: (p: LogLayerTransportParams) => unknown[];
+			}
+		).shipToLogger(params);
+
+		expect(result).toEqual([]);
+		expect(console.info).not.toHaveBeenCalled();
+	});
+
+	it('emits console output with fallback namespace', () => {
+		const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(1234);
+
+		const transport = createTransports('console', 'debug');
+		const params = createParams({
+			logLevel: 'debug',
+			messages: ['hello world'],
+			metadata: { context: { attempt: 1 } },
+			context: {},
+		});
+
+		const output = (
+			transport as {
+				shipToLogger: (p: LogLayerTransportParams) => unknown[];
+			}
+		).shipToLogger(params);
+
+		expect(console.debug).toHaveBeenCalledWith(
+			`[${WPK_NAMESPACE}]`,
+			'hello world',
+			{
+				attempt: 1,
+			}
+		);
+		expect(output).toEqual([
+			`[${WPK_NAMESPACE}]`,
+			'hello world',
+			{ attempt: 1 },
+		]);
+
+		dateSpy.mockRestore();
+	});
+
+	it('sends hook events when WordPress hooks are available', () => {
+		const doAction = window.wp?.hooks?.doAction as jest.Mock | undefined;
+		const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(4321);
+
+		const transport = createTransports('hooks', 'error');
+		const params = createParams({
+			logLevel: 'error',
+			messages: ['failed to fetch'],
+			context: { namespace: 'demo' },
+			metadata: { context: { requestId: '123' } },
+		});
+
+		const payloads = (
+			transport as {
+				shipToLogger: (p: LogLayerTransportParams) => unknown[];
+			}
+		).shipToLogger(params);
+
+		expect(doAction).toHaveBeenCalledWith('demo.reporter.error', {
+			message: 'failed to fetch',
+			context: { requestId: '123' },
+			timestamp: 4321,
+		});
+		expect(payloads).toEqual([
+			expect.objectContaining({
+				message: 'failed to fetch',
+				context: { requestId: '123' },
+				timestamp: 4321,
+			}),
+		]);
+
+		dateSpy.mockRestore();
+	});
+
+	it('returns empty payload when hooks transport cannot access WordPress hooks', () => {
+		const originalDoAction = window.wp?.hooks?.doAction;
+		if (window.wp?.hooks) {
+			window.wp.hooks.doAction =
+				undefined as unknown as typeof window.wp.hooks.doAction;
+		}
+
+		const transport = createTransports('hooks', 'info');
+		const result = (
+			transport as {
+				shipToLogger: (p: LogLayerTransportParams) => unknown[];
+			}
+		).shipToLogger(createParams());
+
+		expect(result).toEqual([]);
+
+		if (window.wp?.hooks) {
+			window.wp.hooks.doAction =
+				originalDoAction as typeof window.wp.hooks.doAction;
+		}
+	});
+
+	it('creates combined transports when using the "all" channel', () => {
+		const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(9876);
+		const transports = createTransports('all', 'warn') as {
+			shipToLogger: (p: LogLayerTransportParams) => unknown[];
+		}[];
+
+		const params = createParams({
+			logLevel: 'warn',
+			messages: ['combined message'],
+			context: { namespace: 'combo' },
+			metadata: { context: { attempt: 2 } },
+		});
+
+		const results = transports.map((transport) =>
+			transport.shipToLogger(params)
+		);
+
+		expect(transports).toHaveLength(2);
+		expect(console.warn).toHaveBeenCalledWith(
+			'[combo]',
+			'combined message',
+			{ attempt: 2 }
+		);
+		expect(window.wp?.hooks?.doAction).toHaveBeenCalledWith(
+			'combo.reporter.warn',
+			{
+				message: 'combined message',
+				context: { attempt: 2 },
+				timestamp: 9876,
+			}
+		);
+		expect(results).toEqual([
+			['[combo]', 'combined message', { attempt: 2 }],
+			[
+				expect.objectContaining({
+					message: 'combined message',
+					context: { attempt: 2 },
+					timestamp: 9876,
+				}),
+			],
+		]);
+
+		dateSpy.mockRestore();
+	});
+});

--- a/types/@wordpress__element/index.d.ts
+++ b/types/@wordpress__element/index.d.ts
@@ -1,0 +1,6 @@
+declare module '@wordpress/element' {
+	export * from 'react';
+	export { createPortal } from 'react-dom';
+	import React from 'react';
+	export default React;
+}

--- a/types/@wordpress__element/index.d.ts
+++ b/types/@wordpress__element/index.d.ts
@@ -1,48 +1,37 @@
 declare module '@wordpress/element' {
 	import * as React from 'react';
 
+	export { Children } from 'react';
+	export { Component } from 'react';
+	export { PureComponent } from 'react';
+	export { Fragment } from 'react';
+	export { StrictMode } from 'react';
+	export { Suspense } from 'react';
+	export { createElement } from 'react';
+	export { cloneElement } from 'react';
+	export { createRef } from 'react';
+	export { forwardRef } from 'react';
+	export { memo } from 'react';
+	export { lazy } from 'react';
+	export { startTransition } from 'react';
+	export { useCallback } from 'react';
+	export { useContext } from 'react';
+	export { useDebugValue } from 'react';
+	export { useDeferredValue } from 'react';
+	export { useEffect } from 'react';
+	export { useId } from 'react';
+	export { useImperativeHandle } from 'react';
+	export { useInsertionEffect } from 'react';
+	export { useLayoutEffect } from 'react';
+	export { useMemo } from 'react';
+	export { useReducer } from 'react';
+	export { useRef } from 'react';
+	export { useState } from 'react';
+	export { useSyncExternalStore } from 'react';
+	export { useTransition } from 'react';
+
 	export { createPortal } from 'react-dom';
-	export const Children: typeof React.Children;
-	export const Fragment: typeof React.Fragment;
-	export function createElement(
-		type: Parameters<typeof React.createElement>[0],
-		props?: Parameters<typeof React.createElement>[1],
-		...children: Parameters<typeof React.createElement>[2][]
-	): ReturnType<typeof React.createElement>;
-	export function cloneElement(
-		element: Parameters<typeof React.cloneElement>[0],
-		props?: Parameters<typeof React.cloneElement>[1],
-		...children: Parameters<typeof React.cloneElement>[2][]
-	): ReturnType<typeof React.cloneElement>;
-	export function createRef<T>(): React.RefObject<T>;
-	export function forwardRef<T, P = {}>(
-		render: React.ForwardRefRenderFunction<T, P>
-	): React.ForwardRefExoticComponent<
-		React.PropsWithoutRef<P> & React.RefAttributes<T>
-	>;
-	export function memo<T extends React.ComponentType<any>>(
-		Component: T,
-		propsAreEqual?: (
-			prevProps: React.ComponentProps<T>,
-			nextProps: React.ComponentProps<T>
-		) => boolean
-	): T;
-	export const startTransition: typeof React.startTransition;
-	export const useCallback: typeof React.useCallback;
-	export const useContext: typeof React.useContext;
-	export const useEffect: typeof React.useEffect;
-	export const useId: typeof React.useId;
-	export const useMemo: typeof React.useMemo;
-	export const useReducer: typeof React.useReducer;
-	export const useRef: typeof React.useRef;
-	export const useState: typeof React.useState;
-	export const useSyncExternalStore: typeof React.useSyncExternalStore;
-	export const useTransition: typeof React.useTransition;
-	export const useLayoutEffect: typeof React.useLayoutEffect;
-	export const useImperativeHandle: typeof React.useImperativeHandle;
-	export const useDebugValue: typeof React.useDebugValue;
-	export const useDeferredValue: typeof React.useDeferredValue;
-	export const useInsertionEffect: typeof React.useInsertionEffect;
+	export { createRoot, hydrateRoot } from 'react-dom/client';
 
 	const ReactDefault: typeof React;
 	export default ReactDefault;

--- a/types/@wordpress__element/index.d.ts
+++ b/types/@wordpress__element/index.d.ts
@@ -1,6 +1,49 @@
 declare module '@wordpress/element' {
-	export * from 'react';
+	import * as React from 'react';
+
 	export { createPortal } from 'react-dom';
-	import React from 'react';
-	export default React;
+	export const Children: typeof React.Children;
+	export const Fragment: typeof React.Fragment;
+	export function createElement(
+		type: Parameters<typeof React.createElement>[0],
+		props?: Parameters<typeof React.createElement>[1],
+		...children: Parameters<typeof React.createElement>[2][]
+	): ReturnType<typeof React.createElement>;
+	export function cloneElement(
+		element: Parameters<typeof React.cloneElement>[0],
+		props?: Parameters<typeof React.cloneElement>[1],
+		...children: Parameters<typeof React.cloneElement>[2][]
+	): ReturnType<typeof React.cloneElement>;
+	export function createRef<T>(): React.RefObject<T>;
+	export function forwardRef<T, P = {}>(
+		render: React.ForwardRefRenderFunction<T, P>
+	): React.ForwardRefExoticComponent<
+		React.PropsWithoutRef<P> & React.RefAttributes<T>
+	>;
+	export function memo<T extends React.ComponentType<any>>(
+		Component: T,
+		propsAreEqual?: (
+			prevProps: React.ComponentProps<T>,
+			nextProps: React.ComponentProps<T>
+		) => boolean
+	): T;
+	export const startTransition: typeof React.startTransition;
+	export const useCallback: typeof React.useCallback;
+	export const useContext: typeof React.useContext;
+	export const useEffect: typeof React.useEffect;
+	export const useId: typeof React.useId;
+	export const useMemo: typeof React.useMemo;
+	export const useReducer: typeof React.useReducer;
+	export const useRef: typeof React.useRef;
+	export const useState: typeof React.useState;
+	export const useSyncExternalStore: typeof React.useSyncExternalStore;
+	export const useTransition: typeof React.useTransition;
+	export const useLayoutEffect: typeof React.useLayoutEffect;
+	export const useImperativeHandle: typeof React.useImperativeHandle;
+	export const useDebugValue: typeof React.useDebugValue;
+	export const useDeferredValue: typeof React.useDeferredValue;
+	export const useInsertionEffect: typeof React.useInsertionEffect;
+
+	const ReactDefault: typeof React;
+	export default ReactDefault;
 }

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -54,7 +54,11 @@ export const createKernelLibConfig = (
 		plugins: [
 			dts({
 				// Generate TypeScript declarations
-				include: ['src/**/*.ts', 'src/**/*.tsx'],
+				include: [
+					'src/**/*.ts',
+					'src/**/*.tsx',
+					'../../types/**/*.d.ts',
+				],
 				outDir: 'dist',
 				rollupTypes: false, // Don't bundle types (avoids TS version mismatch warning)
 			}),


### PR DESCRIPTION
## Summary
- add regression-focused unit tests for kernel event plugin edge cases and store registration
- exercise reporter transports across console and hooks scenarios with new coverage
- introduce an integration test for end-to-end error reporting and provide a stub module for `@wordpress/element`

## Testing
- CI=1 pnpm typecheck
- CI=1 pnpm typecheck:tests
- CI=1 pnpm test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e2929b4b248325b12d23a3784c4341