### PR TITLE
Sprint 9: Kernel UI runtime hardening

### DIFF
--- a/docs/api/useAction.md
+++ b/docs/api/useAction.md
@@ -7,10 +7,13 @@ the lifecycle instrumentation provided by `defineAction`
 (`packages/kernel/src/actions/define.ts`) while gaining a first-class React
 interface.
 
-The hook lives in `@geekist/wp-kernel-ui` and expects the kernel middleware to
-be registered in the WordPress data registry (via `withKernel`). It does **not**
-reimplement Actions-everything still flows through `invokeAction` and the
-runtime declared in `packages/kernel/src/actions/types.ts`.
+The hook lives in `@geekist/wp-kernel-ui` and expects a `KernelUIRuntime` to be
+available via `KernelUIProvider`. Attach the runtime during
+`configureKernel({ ui: { attach: attachUIBindings } })` and wrap your React tree
+with `KernelUIProvider` so hooks can resolve the registry and action dispatcher.
+`useAction()` does **not** reimplement actions-everything still flows through
+`invokeAction` and the runtime declared in
+`packages/kernel/src/actions/types.ts`.
 
 ## Signature
 
@@ -152,8 +155,10 @@ export function SearchBox() {
 ## SSR
 
 The module can be imported in server contexts. Calling `run()` requires
-`window.wp.data` to be available (the hook throws a `KernelError('DeveloperError')`
-otherwise). This mirrors the behaviour of the kernel runtime.
+`window.wp.data` **and** an attached UI runtime (the hook throws a
+`KernelError('DeveloperError')` otherwise). This mirrors the behaviour of the
+kernel runtime and prevents hooks from running before the browser environment is
+available.
 
 ## References
 

--- a/docs/guide/actions.md
+++ b/docs/guide/actions.md
@@ -258,6 +258,10 @@ function PostForm() {
 }
 ```
 
+> ℹ️ Wrap your application with `KernelUIProvider` after calling
+> `configureKernel({ ui: { attach: attachUIBindings } })` so that `useAction()`
+> can resolve the action dispatcher from the runtime.
+
 `useAction` exposes the request lifecycle (`status`, `error`, `result`) and
 allows you to tune concurrency:
 

--- a/docs/guide/prefetching.md
+++ b/docs/guide/prefetching.md
@@ -5,6 +5,10 @@ whether or not a prefetch fires. These helpers exist to warm the cache ahead of
 likely navigation, so when the user finally clicks the link the data is already
 waiting in the store.
 
+> ℹ️ Prefetching hooks read from the `KernelUIRuntime`. Attach UI bindings during
+> `configureKernel({ ui: { attach: attachUIBindings } })` and wrap your React tree
+> with `KernelUIProvider` so the runtime is available.
+
 ## When to prefetch
 
 - **Detail hovers** – links in tables, context menus, or tooltips where the next

--- a/docs/guide/resources.md
+++ b/docs/guide/resources.md
@@ -64,12 +64,16 @@ await CreateTestimonial({ data: { title: 'Great service!', rating: 5 } });
 
 // ✓ Use React hooks (read path)
 function TestimonialList() {
-	const { data, isLoading } = testimonial.useList({ rating: 5 });
+        const { data, isLoading } = testimonial.useList({ rating: 5 });
 
-	if (isLoading) return <Spinner />;
-	return <ul>{data?.items.map(item => <li key={item.id}>{item.title}</li>)}</ul>;
+        if (isLoading) return <Spinner />;
+        return <ul>{data?.items.map(item => <li key={item.id}>{item.title}</li>)}</ul>;
 }
 ```
+
+> ℹ️ Hook access (`useList`, `useGet`) requires a configured `KernelUIRuntime`.
+> Call `configureKernel({ ui: { attach: attachUIBindings } })` and wrap your React
+> tree with `KernelUIProvider` to make the runtime available.
 
 ## Configuration
 

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -147,6 +147,32 @@ Required dependencies that must be installed alongside:
 - `@wordpress/element` - WordPress React wrapper
 - `react` (18+) - React library
 
+## Runtime Integration
+
+UI hooks and components resolve their configuration through the `KernelUIRuntime` returned by `configureKernel()`. Instead of importing `@geekist/wp-kernel-ui` for side effects, attach the runtime explicitly and wrap your React tree with `KernelUIProvider`.
+
+```tsx
+import { createRoot } from 'react-dom/client';
+import { configureKernel } from '@geekist/wp-kernel';
+import { attachUIBindings, KernelUIProvider } from '@geekist/wp-kernel-ui';
+
+const kernel = configureKernel({
+	namespace: 'demo',
+	registry: window.wp.data,
+	ui: { attach: attachUIBindings },
+});
+
+const runtime = kernel.getUIRuntime();
+
+createRoot(document.getElementById('app')!).render(
+	<KernelUIProvider runtime={runtime}>
+		<App />
+	</KernelUIProvider>
+);
+```
+
+Hooks such as `useAction()`, `useResourceList()`, and future UI primitives will throw a typed `KernelError` if the runtime has not been attached. In non-React environments you can call `kernel.attachUIBindings(attachUIBindings)` on demand and access the runtime directly.
+
 ## Integration Examples
 
 ### Admin Dashboard Component

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -17,14 +17,16 @@ module.exports = {
 	],
 
 	// Module resolution
-	moduleNameMapper: {
-		// Strip .js extensions for Jest (TypeScript source files are .ts)
-		'^(\\.{1,2}/.*)\\.js$': '$1',
-		// Test utilities (with and without .js extension)
-		'^@test-utils/(.*)\\.js$': '<rootDir>/tests/test-utils/$1',
-		'^@test-utils/(.*)$': '<rootDir>/tests/test-utils/$1',
-		// Workspace package aliases
-		'^@geekist/wp-kernel$': '<rootDir>/packages/kernel/src',
+        moduleNameMapper: {
+                // Strip .js extensions for Jest (TypeScript source files are .ts)
+                '^(\\.{1,2}/.*)\\.js$': '$1',
+                // Test utilities (with and without .js extension)
+                '^@test-utils/(.*)\\.js$': '<rootDir>/tests/test-utils/$1',
+                '^@test-utils/(.*)$': '<rootDir>/tests/test-utils/$1',
+                // Ensure automatic JSX runtime resolves during tests
+                '^@wordpress/element/jsx-runtime$': 'react/jsx-runtime',
+                // Workspace package aliases
+                '^@geekist/wp-kernel$': '<rootDir>/packages/kernel/src',
 		'^@geekist/wp-kernel/(.*)$': '<rootDir>/packages/kernel/src/$1',
 		'^@geekist/wp-kernel-ui$': '<rootDir>/packages/ui/src',
 		'^@geekist/wp-kernel-ui/(.*)$': '<rootDir>/packages/ui/src/$1',

--- a/packages/kernel/CHANGELOG.md
+++ b/packages/kernel/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### Minor Changes
 
-- **Sprint 5: React Hooks Integration**
-    - Modified `defineResource()` to support lazy hook attachment via global queue mechanism
-    - Added resource hook queuing for resources defined before UI package loads
-    - Exposed `__WP_KERNEL_UI_PROCESS_PENDING_RESOURCES__` global for pending resource processing
-    - Enhanced resource-to-hook binding with comprehensive JSDoc documentation
+- Introduced `kernel.attachUIBindings()`, `kernel.getUIRuntime()`, and
+  `kernel.hasUIRuntime()` to manage UI adapters without global mutation.
+- `defineResource()` now registers resources with the runtime via
+  `trackUIResource()` instead of relying on queued globals.
 
 ### Technical Details
 
-- Module-level queue in `resource/define.ts` (lines 28-50, 377-413)
-- Global hooks: `__WP_KERNEL_UI_ATTACH_RESOURCE_HOOKS__`, `__WP_KERNEL_UI_PROCESS_PENDING_RESOURCES__`
-- Ensures resources defined before UI loads can still bind React hooks when UI initializes
+- UI runtime state lives in `data/ui-runtime.ts`, flushing pending resources when
+  adapters attach.
+- `resource/define.ts` calls `trackUIResource()` so hooks attach immediately once
+  a runtime is available.
 
 ## 0.2.0
 

--- a/packages/ui/src/hooks/__tests__/useAction.test.tsx
+++ b/packages/ui/src/hooks/__tests__/useAction.test.tsx
@@ -499,13 +499,10 @@ describe('useAction', () => {
 	it('throws when WordPress data registry dispatch API is unavailable', () => {
 		const action = makeDefinedAction(async () => 'noop');
 		const dispatchMock = window.wp?.data?.dispatch as jest.Mock;
-		dispatchMock.mockReturnValueOnce({});
+		dispatchMock.mockReset();
+		dispatchMock.mockImplementation(() => ({}));
 
-		const { result } = renderHook(() => useAction(action));
-
-		expect(() => {
-			result.current.run({} as never);
-		}).toThrow(
+		expect(() => renderUseActionHook(action)).toThrow(
 			expect.objectContaining({
 				name: 'KernelError',
 				code: 'DeveloperError',
@@ -514,6 +511,8 @@ describe('useAction', () => {
 				),
 			})
 		);
+
+		dispatchMock.mockReset();
 	});
 
 	it('ignores duplicate store registration errors', async () => {
@@ -702,16 +701,13 @@ describe('useAction', () => {
 		windowWithWp.wp = undefined;
 
 		const action = makeDefinedAction(async () => 'noop');
-		const { result } = renderHook(() => useAction(action));
 
-		expect(() => {
-			result.current.run({} as never);
-		}).toThrow(
+		expect(() => renderUseActionHook(action)).toThrow(
 			expect.objectContaining({
 				name: 'KernelError',
 				code: 'DeveloperError',
 				message: expect.stringContaining(
-					'useAction requires the WordPress data registry'
+					'Kernel UI runtime requires the WordPress data registry'
 				),
 			})
 		);

--- a/types/wordpress-element-jsx-runtime.d.ts
+++ b/types/wordpress-element-jsx-runtime.d.ts
@@ -1,0 +1,4 @@
+declare module '@wordpress/element/jsx-runtime' {
+	export * from 'react/jsx-runtime';
+	export { default } from 'react/jsx-runtime';
+}


### PR DESCRIPTION
## Summary
Sprint 9: Kernel UI runtime hardening — align Jest and UI tests with the explicit runtime contract.

**Sprint:** 9 (Kernel UI runtime hardening)
**Scope:** data · ui

## Links
- Roadmap section: N/A
- Sprint doc / spec: Architecture Implementation Phases — Phase 2
- Related issues: N/A
- Demo/preview (if any): N/A

## Why
Jest could not resolve `@wordpress/element/jsx-runtime`, breaking the UI test suite, and several `useAction` assertions still assumed the legacy global shim instead of the new runtime contract.

## What
- Map `@wordpress/element/jsx-runtime` to `react/jsx-runtime` in the Jest configuration.
- Extend the UI action tests to expect runtime failures at render-time and reset the mocked registry between checks.
- Provide a TypeScript stub so `tsc` recognises the JSX runtime module.

## How
Point the Jest resolver at React’s JSX runtime, update the UI tests to construct runtimes and assert against the runtime errors thrown during initialisation, and add a project-wide declaration that aliases the WordPress JSX runtime module to React’s implementation for type-checking.

## Testing
How reviewers test locally:

1. `pnpm test`
   **Expected:** All Jest suites pass.
2. `pnpm typecheck`
   **Expected:** No TypeScript errors for source files.
3. `pnpm typecheck:tests`
   **Expected:** Test TypeScript projects succeed.
4. `pnpm --filter @geekist/wp-kernel build`
   **Expected:** Kernel package builds without errors.

### Test Matrix (tick what’s covered)

- [x] Unit (pnpm test)
- [ ] E2E (pnpm e2e)
- [x] Types (pnpm typecheck)
- [x] Docs examples (build/run)
- [ ] WordPress playground / wp-env sanity

## Screenshots / Recordings (if applicable)

N/A

## Breaking Changes

- [x] None

## Affected Packages

- [ ] `@geekist/wp-kernel`
- [x] `@geekist/wp-kernel-ui`
- [ ] `@geekist/wp-kernel-cli`
- [ ] `@geekist/wp-kernel-e2e-utils`

## Release

- [x] **patch** — bugfixes / alignment (0.x.1)
- [ ] **minor** — feature sprint (default) (0.x.0)
- [ ] **major** — breaking API (x.0.0)

## Checklist

- [x] Tests pass (`pnpm test`, where relevant: `pnpm e2e`)
- [ ] Lint passes (`pnpm lint`)
- [x] Types pass (`pnpm typecheck`, `pnpm typecheck:tests`)
- [x] CHANGELOG.md updated in affected packages (or PR labelled `no-release`)
- [x] Docs updated (site/README)
- [ ] Examples updated (if API changed)

------
https://chatgpt.com/codex/tasks/task_e_68e64519f9348325b91755e98ba70eae